### PR TITLE
Change Tabs component interface

### DIFF
--- a/src/components/hello_world.vue
+++ b/src/components/hello_world.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <!-- <ButtonDemo></ButtonDemo>
+    <ButtonDemo></ButtonDemo>
     <ColorPaletteDemo></ColorPaletteDemo>
     <ContextMenuDemo></ContextMenuDemo>
     <CourseListDemo></CourseListDemo>
@@ -9,11 +9,11 @@
     <DropdownTypeaheadDemo></DropdownTypeaheadDemo>
     <ModalDemo></ModalDemo>
     <FileUploadDemo></FileUploadDemo>
-    <MultiFileViewerDemo></MultiFileViewerDemo> -->
+    <MultiFileViewerDemo></MultiFileViewerDemo>
     <TabsDemo></TabsDemo>
-    <!-- <TooltipDemo></TooltipDemo>
+    <TooltipDemo></TooltipDemo>
     <ToggleDemo></ToggleDemo>
-    <ViewFileDemo></ViewFileDemo> -->
+    <ViewFileDemo></ViewFileDemo>
   </div>
 </template>
 

--- a/src/components/hello_world.vue
+++ b/src/components/hello_world.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <ButtonDemo></ButtonDemo>
+    <!-- <ButtonDemo></ButtonDemo>
     <ColorPaletteDemo></ColorPaletteDemo>
     <ContextMenuDemo></ContextMenuDemo>
     <CourseListDemo></CourseListDemo>
@@ -9,11 +9,11 @@
     <DropdownTypeaheadDemo></DropdownTypeaheadDemo>
     <ModalDemo></ModalDemo>
     <FileUploadDemo></FileUploadDemo>
-    <MultiFileViewerDemo></MultiFileViewerDemo>
+    <MultiFileViewerDemo></MultiFileViewerDemo> -->
     <TabsDemo></TabsDemo>
-    <TooltipDemo></TooltipDemo>
+    <!-- <TooltipDemo></TooltipDemo>
     <ToggleDemo></ToggleDemo>
-    <ViewFileDemo></ViewFileDemo>
+    <ViewFileDemo></ViewFileDemo> -->
   </div>
 </template>
 

--- a/src/components/multi_file_viewer.vue
+++ b/src/components/multi_file_viewer.vue
@@ -4,17 +4,14 @@
           v-model="active_tab_index"
           tab_active_class="gray-white-theme-active"
           tab_inactive_class="gray-white-theme-inactive">
-       <tab ref="single-tab"
-            v-for="(open_file, index) of files_currently_viewing"
-            @click="active_tab_index = index">
-
-         <template slot="header">
+       <tab v-for="(open_file, index) of files_currently_viewing">
+         <tab-header @click.native="active_tab_index = index">
            <div class="tab-header">
              <p class="tab-label"> {{ open_file.name }} </p>
              <i class="fas fa-times close-x"
                 @click="$event.stopPropagation(); remove_from_viewing(index)"></i>
            </div>
-         </template>
+         </tab-header>
 
          <template slot="body">
            <div class="tab-body">
@@ -38,6 +35,7 @@
   import { Component, Prop, Vue } from 'vue-property-decorator';
 
   import Tab from '@/components/tabs/tab.vue';
+  import TabHeader from '@/components/tabs/tab_header.vue';
   import Tabs from '@/components/tabs/tabs.vue';
   import ViewFile from '@/components/view_file.vue';
 

--- a/src/components/tabs/tab.vue
+++ b/src/components/tabs/tab.vue
@@ -1,7 +1,7 @@
 <template>
 
 <div>
-  <slot name="header"></slot>
+  <slot></slot>
   <slot name="body"></slot>
 </div>
 

--- a/src/components/tabs/tab_header.vue
+++ b/src/components/tabs/tab_header.vue
@@ -1,0 +1,56 @@
+<template>
+
+<div class="tab-header"
+     :class="[
+       {'inactive-tab-header': !is_active},
+       is_active ? active_tab_class : inactive_tab_class
+     ]"
+     :click="on_click_fn">
+  <slot></slot>
+</div>
+
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+@Component
+export default class TabHeader extends Vue {
+  @Prop({default: false, type: Boolean})
+  is_active!: boolean;
+
+  @Prop({default: 'white-theme-active', type: String})
+  active_tab_class!: string;
+
+  @Prop({default: 'white-theme-inactive', type: String})
+  inactive_tab_class!: string;
+
+  @Prop({default: (event: Event) => {}, type: Function})
+  on_click_fn!: (event: Event) => void;
+
+  // d_is_active = false;
+  // d_active_tab_class = 'white-theme-active';
+  // d_inactive_tab_class = 'white-theme-inactive';
+  // d_on_click_fn = (event: Event) => {};
+}
+
+</script>
+
+
+<style scoped lang="scss">
+@import '@/styles/components/tab_styles.scss';
+
+.tab-header {
+  display: inline-block;
+
+  border-radius: 10px 10px 0 0;
+  margin-right: 2px;
+  margin-top: 4px;
+  padding: 10px 15px;
+}
+
+.inactive-tab-header:hover {
+  cursor: pointer;
+}
+
+</style>

--- a/src/components/tabs/tab_header.vue
+++ b/src/components/tabs/tab_header.vue
@@ -1,6 +1,6 @@
 <template>
 
-<div class="tab-header">
+<div>
   <slot></slot>
 </div>
 
@@ -17,15 +17,6 @@ export default class TabHeader extends Vue {}
 
 <style scoped lang="scss">
 @import '@/styles/components/tab_styles.scss';
-
-.tab-header {
-  display: inline-block;
-
-  border-radius: 10px 10px 0 0;
-  margin-right: 2px;
-  margin-top: 4px;
-  padding: 10px 15px;
-}
 
 .inactive-tab-header:hover {
   cursor: pointer;

--- a/src/components/tabs/tab_header.vue
+++ b/src/components/tabs/tab_header.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 
 @Component
 export default class TabHeader extends Vue {}

--- a/src/components/tabs/tab_header.vue
+++ b/src/components/tabs/tab_header.vue
@@ -1,11 +1,6 @@
 <template>
 
-<div class="tab-header"
-     :class="[
-       {'inactive-tab-header': !is_active},
-       is_active ? active_tab_class : inactive_tab_class
-     ]"
-     :click="on_click_fn">
+<div class="tab-header">
   <slot></slot>
 </div>
 
@@ -15,24 +10,7 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 @Component
-export default class TabHeader extends Vue {
-  @Prop({default: false, type: Boolean})
-  is_active!: boolean;
-
-  @Prop({default: 'white-theme-active', type: String})
-  active_tab_class!: string;
-
-  @Prop({default: 'white-theme-inactive', type: String})
-  inactive_tab_class!: string;
-
-  @Prop({default: (event: Event) => {}, type: Function})
-  on_click_fn!: (event: Event) => void;
-
-  // d_is_active = false;
-  // d_active_tab_class = 'white-theme-active';
-  // d_inactive_tab_class = 'white-theme-inactive';
-  // d_on_click_fn = (event: Event) => {};
-}
+export default class TabHeader extends Vue {}
 
 </script>
 

--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 
-import { CreateElement, VNode, VNodeData } from 'vue';
+import { CreateElement, VNode, VNodeData, VNodeChildren } from 'vue';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
 import Tab from '@/components/tabs/tab.vue';
@@ -127,10 +127,16 @@ export default class Tabs extends Vue {
 
         element_data.nativeOn.click.push(() => this._set_active_tab(index));
 
-        return create_element(
-          'tab-header',
-          element_data,
-          header.componentOptions === undefined ? [] : header.componentOptions.children);
+        let children: VNode[] | VNodeChildren = [];
+        if (header.children !== undefined) {
+          children = header.children;
+        }
+        else if (header.componentOptions !== undefined
+                 && header.componentOptions.children !== undefined) {
+          children = header.componentOptions.children;
+        }
+
+        return create_element('tab-header', element_data, children);
       }
     );
 

--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 
-import { CreateElement, VNode, VNodeData, VNodeChildren } from 'vue';
+import { CreateElement, VNode, VNodeChildren } from 'vue';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
 import Tab from '@/components/tabs/tab.vue';
@@ -72,9 +72,6 @@ export default class Tabs extends Vue {
   private _find_header(tab_children: VNode[]) {
     let header = tab_children.find(
       (vnode: VNode) =>  {
-        if (vnode === undefined) {
-          return false;
-        }
         return vnode.tag === 'tab-header'
                || (vnode.componentOptions !== undefined
                     && vnode.componentOptions.tag === 'tab-header');
@@ -127,6 +124,14 @@ export default class Tabs extends Vue {
 
         element_data.nativeOn.click.push(() => this._set_active_tab(index));
 
+        // If TabHeader is explicitly registered with the parent
+        // component, children will be available at header.componentOptions.children.
+        // Otherwise, children will be available at header.children.
+        // At time of writing, this was determined by examining the
+        // Vue source code at:
+        //    https://github.com/vuejs/vue/blob/dev/src/core/vdom/create-element.js#L107
+        //    and
+        //    https://github.com/vuejs/vue/blob/dev/src/core/vdom/create-element.js#L112
         let children: VNode[] | VNodeChildren = [];
         if (header.children !== undefined) {
           children = header.children;

--- a/src/demos/tabs_demo.vue
+++ b/src/demos/tabs_demo.vue
@@ -111,7 +111,6 @@
     height: 500px;
     position: relative;
     bottom: 0;
-    z-index: 15;
   }
 
   .tab-body2 {
@@ -121,7 +120,6 @@
     height: 500px;
     position: relative;
     bottom: 0;
-    z-index: 15;
   }
 
   .tab-heading {

--- a/src/demos/tabs_demo.vue
+++ b/src/demos/tabs_demo.vue
@@ -7,41 +7,51 @@
       <br> <br>
       <div class="shrink-tabs">
         <p> Current Tab Index = {{current_tab_index}}</p>
-        <tabs ref="tabs" v-model="current_tab_index"
-              tab_active_class="no-border-active"
-              tab_inactive_class="no-border-inactive">
-          <tab v-for="(tab_val, index) in tab_labels" :key="tab_val">
-            <tab-header v-on:click="log_event">
-              <span class="tab-heading"> Tab {{tab_val}} </span>
-              <i class="fas fa-times close_x"
-                  @click="$event.stopPropagation(); remove_tab(index)"></i>
-            </tab-header>
-            <template slot="body">
-              <div class="tab-body">
-                {{tab_val}}
-              </div>
-            </template>
-          </tab>
-        </tabs>
+        <!--<tabs ref="tabs" v-model="current_tab_index"-->
+              <!--tab_active_class="no-border-active"-->
+              <!--tab_inactive_class="no-border-inactive">-->
+          <!--<tab v-for="(tab_val, index) in tab_labels" :key="tab_val">-->
+            <!--<tab-header v-on:click="log_event">-->
+              <!--<span class="tab-heading"> Tab {{tab_val}} </span>-->
+              <!--<i class="fas fa-times close_x"-->
+                  <!--@click="$event.stopPropagation(); remove_tab(index)"></i>-->
+            <!--</tab-header>-->
+            <!--<template slot="body">-->
+              <!--<div class="tab-body">-->
+                <!--{{tab_val}}-->
+              <!--</div>-->
+            <!--</template>-->
+          <!--</tab>-->
+        <!--</tabs>-->
 
         <!-- This one uses the default styling -->
         <tabs ref="tabs2">
+          <!--<tab>-->
+            <!--<tab-header v-on:click="log_event">-->
+              <!--<p class="tab-heading"> Cat Tab </p>-->
+            <!--</tab-header>-->
+            <!--<template slot="body">-->
+              <!--<div class="tab-body2">-->
+              <!--</div>-->
+            <!--</template>-->
+          <!--</tab>-->
           <tab>
-            <tab-header v-on:click="log_event">
-              <p class="tab-heading"> Cat Tab </p>
-            </tab-header>
-            <template slot="body">
-              <div class="tab-body2">
-              </div>
-            </template>
-          </tab>
-          <tab>
-            <tab-header v-on:click="log_event">
+            <tab-header v-on:click.native="log_event">
               <p class="tab-heading"> Dog Tab </p>
             </tab-header>
             <template slot="body">
               <div class="tab-body2">
                 Bye 2
+              </div>
+            </template>
+          </tab>
+          <tab>
+            <tab-header @click.native="log_event">
+              Bare Text Tab
+            </tab-header>
+            <template slot="body">
+              <div class="tab-body2">
+                The tab header has just text
               </div>
             </template>
           </tab>

--- a/src/demos/tabs_demo.vue
+++ b/src/demos/tabs_demo.vue
@@ -10,15 +10,12 @@
         <tabs ref="tabs" v-model="current_tab_index"
               tab_active_class="no-border-active"
               tab_inactive_class="no-border-inactive">
-          <tab ref="tabby" v-on:click="log_event"
-               v-for="(tab_val, index) in tab_labels" :key="tab_val">
-            <template slot="header">
-              <div class="tab-label">
-                <p class="tab-heading"> Tab {{tab_val}} </p>
-                <i class="fas fa-times close_x"
-                   @click="$event.stopPropagation(); remove_tab(index)"></i>
-              </div>
-            </template>
+          <tab v-for="(tab_val, index) in tab_labels" :key="tab_val">
+            <tab-header v-on:click="log_event">
+              <span class="tab-heading"> Tab {{tab_val}} </span>
+              <i class="fas fa-times close_x"
+                  @click="$event.stopPropagation(); remove_tab(index)"></i>
+            </tab-header>
             <template slot="body">
               <div class="tab-body">
                 {{tab_val}}
@@ -27,26 +24,21 @@
           </tab>
         </tabs>
 
-        <tabs ref="tabs2"
-              tab_active_class="white-theme-active"
-              tab_inactive_class="white-theme-inactive">
-          <tab ref="tabby" v-on:click="log_event">
-            <template slot="header">
-              <div class="tab-label">
-                <p class="tab-heading"> Cat Tab </p>
-              </div>
-            </template>
+        <!-- This one uses the default styling -->
+        <tabs ref="tabs2">
+          <tab>
+            <tab-header v-on:click="log_event">
+              <p class="tab-heading"> Cat Tab </p>
+            </tab-header>
             <template slot="body">
               <div class="tab-body2">
               </div>
             </template>
           </tab>
-          <tab ref="tabby" v-on:click="log_event">
-            <template slot="header">
-              <div class="tab-label">
-                <p class="tab-heading"> Dog Tab </p>
-              </div>
-            </template>
+          <tab>
+            <tab-header v-on:click="log_event">
+              <p class="tab-heading"> Dog Tab </p>
+            </tab-header>
             <template slot="body">
               <div class="tab-body2">
                 Bye 2
@@ -64,11 +56,12 @@
   import { Component, Prop, Vue } from 'vue-property-decorator';
 
   import Tab from '@/components/tabs/tab.vue';
+  import TabHeader from '@/components/tabs/tab_header.vue';
   import Tabs from '@/components/tabs/tabs.vue';
   import ViewFile from '@/components/view_file.vue';
 
   @Component({
-    components: {Tabs, Tab, ViewFile}
+    components: {Tabs, TabHeader, Tab, ViewFile}
   })
   export default class TabsDemo extends Vue {
     log_event(e: Event) {
@@ -121,14 +114,9 @@
     z-index: 15;
   }
 
-  .tab-label {
-    margin: 0;
-  }
-
   .tab-heading {
     margin: 0;
     padding-right: 15px;
-    display: inline-block;
     font-family: "Helvetica Neue", Helvetica;
   }
 

--- a/src/demos/tabs_demo.vue
+++ b/src/demos/tabs_demo.vue
@@ -7,34 +7,34 @@
       <br> <br>
       <div class="shrink-tabs">
         <p> Current Tab Index = {{current_tab_index}}</p>
-        <!--<tabs ref="tabs" v-model="current_tab_index"-->
-              <!--tab_active_class="no-border-active"-->
-              <!--tab_inactive_class="no-border-inactive">-->
-          <!--<tab v-for="(tab_val, index) in tab_labels" :key="tab_val">-->
-            <!--<tab-header v-on:click="log_event">-->
-              <!--<span class="tab-heading"> Tab {{tab_val}} </span>-->
-              <!--<i class="fas fa-times close_x"-->
-                  <!--@click="$event.stopPropagation(); remove_tab(index)"></i>-->
-            <!--</tab-header>-->
-            <!--<template slot="body">-->
-              <!--<div class="tab-body">-->
-                <!--{{tab_val}}-->
-              <!--</div>-->
-            <!--</template>-->
-          <!--</tab>-->
-        <!--</tabs>-->
+        <tabs ref="tabs" v-model="current_tab_index"
+              tab_active_class="no-border-active"
+              tab_inactive_class="no-border-inactive">
+          <tab v-for="(tab_val, index) in tab_labels" :key="tab_val">
+            <tab-header v-on:click="log_event">
+              <span class="tab-heading"> Tab {{tab_val}} </span>
+              <i class="fas fa-times close_x"
+                  @click="$event.stopPropagation(); remove_tab(index)"></i>
+            </tab-header>
+            <template slot="body">
+              <div class="tab-body">
+                {{tab_val}}
+              </div>
+            </template>
+          </tab>
+        </tabs>
 
         <!-- This one uses the default styling -->
         <tabs ref="tabs2">
-          <!--<tab>-->
-            <!--<tab-header v-on:click="log_event">-->
-              <!--<p class="tab-heading"> Cat Tab </p>-->
-            <!--</tab-header>-->
-            <!--<template slot="body">-->
-              <!--<div class="tab-body2">-->
-              <!--</div>-->
-            <!--</template>-->
-          <!--</tab>-->
+          <tab>
+            <tab-header v-on:click="log_event">
+              <p class="tab-heading"> Cat Tab </p>
+            </tab-header>
+            <template slot="body">
+              <div class="tab-body2">
+              </div>
+            </template>
+          </tab>
           <tab>
             <tab-header v-on:click.native="log_event">
               <p class="tab-heading"> Dog Tab </p>

--- a/src/styles/components/tab_styles.scss
+++ b/src/styles/components/tab_styles.scss
@@ -1,156 +1,142 @@
 @import '@/styles/colors.scss';
 
-%behind-the-border {
-    position: relative;
-    top: 2px;
-    z-index: 3;
+%tab-theme {
+    display: inline-block;
+    border-radius: 10px 10px 0 0;
+    margin-right: 2px;
+    margin-top: 4px;
+    padding: 10px 15px;
 }
 
-%in-front-of-the-border {
+@mixin inactive-tab-position($border-width: 2px) {
     position: relative;
-    top: 2px;
-    z-index: 20;
+    top: $border-width;
+}
+
+@mixin active-tab-position($border-width: 2px) {
+    position: relative;
+    top: $border-width;
+    z-index: 1;
+}
+
+@mixin tab-border($border-color, $border-width: 2px) {
+    border: $border-width solid $border-color;
+    border-bottom: $border-width solid transparent;
 }
 
 /* ---------------- Gray ---------------- */
 
 .gray-theme-active {
-    @extend %in-front-of-the-border;
+    @extend %tab-theme;
+    @include active-tab-position();
     background-color: white;
-    border: 2px solid slategrey;
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px white;
+    @include tab-border(slategrey);
     color: slategrey;
 };
 
 .gray-theme-inactive {
-    @extend %behind-the-border;
+    @extend %tab-theme;
+    @include inactive-tab-position();
     background-color: $pebble-medium;
-    border: 2px solid $pebble-medium;
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px $pebble-medium;
+    @include tab-border($pebble-medium);
     color: slategrey;
 };
 
 .gray-theme-inactive:hover {
-    @extend %behind-the-border;
     background-color: slategrey;
-
-    border: 2px solid slategrey;
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px slategrey;
+    @include tab-border(slategray);
     color: white;
 }
 
 /* ---------------- Blue ---------------- */
 
 .blue-theme-active {
-    @extend %in-front-of-the-border;
+    @extend %tab-theme;
+    @include active-tab-position();
     background-color: white;
-    border: 2px solid $ocean-blue;
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px white;
+    @include tab-border($ocean-blue);
     color: black;
 }
 
 .blue-theme-inactive {
-    @extend %behind-the-border;
+    @extend %tab-theme;
+    @include inactive-tab-position();
     background-color: hsl(30, 100%, 68%);
-    border: 2px solid hsl(30, 100%, 68%);
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px hsl(30, 100%, 68%);
+    @include tab-border(hsl(30, 100%, 68%));
     color: white;
 }
 
 .blue-theme-inactive:hover  {
-    @extend %behind-the-border;
     background-color: hsl(30, 100%, 60%);
-    border: 2px solid hsl(30, 100%, 60%);
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px hsl(30, 100%, 60%);
-    color: white;
+    @include tab-border(hsl(30, 100%, 60%));
 }
 
 /* ---------------- White ---------------- */
 
 .white-theme-active {
-    @extend %in-front-of-the-border;
+    @extend %tab-theme;
+    @include active-tab-position();
     background-color: white;
-    border: 2px solid $pebble-dark;
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px white;
+    @include tab-border($pebble-dark);
     color: black;
 }
 
 .white-theme-inactive {
-    @extend %behind-the-border;
+    @extend %tab-theme;
+    @include inactive-tab-position();
     background-color: white;
-    border: 2px solid white;
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px white;
+    @include tab-border(white);
     color: slategrey;
 }
 
 .white-theme-inactive:hover {
-    @extend %behind-the-border;
     background-color: $pebble-dark;
-    border: 2px solid $pebble-dark;
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px $pebble-dark;
+    @include tab-border($pebble-dark);
     color: black;
 }
 
-/* -------------- No Border ------------- */
+/* -------------- Gray-white ------------- */
 
 .gray-white-theme-active {
-    @extend %in-front-of-the-border;
+    @extend %tab-theme;
+    @include active-tab-position();
     background-color: white;
-    border: 2px solid hsl(210, 11%, 90%);
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px white;
-    color: black;
-}
-
-.gray-white-theme-inactive:hover {
-    @extend %behind-the-border;
-    background-color: hsl(210, 12%, 93%);
-    border: 2px solid hsl(210, 12%, 93%);
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px hsl(210, 12%, 93%);
+    @include tab-border(hsl(210, 11%, 90%));
     color: black;
 }
 
 .gray-white-theme-inactive {
-    @extend %behind-the-border;
+    @extend %tab-theme;
+    @include inactive-tab-position();
     background-color: hsl(210, 11%, 95%);
-    border: 2px solid hsl(210, 11%, 95%);
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px hsl(210, 11%, 95%);
+    @include tab-border(hsl(210, 11%, 95%));
+    color: black;
+}
+
+.gray-white-theme-inactive:hover {
+    background-color: hsl(210, 12%, 93%);
+    @include tab-border(hsl(210, 12%, 93%));
     color: black;
 }
 
 /* -------------- No Border ------------- */
 
 .no-border-active {
+    @extend %tab-theme;
     background-color: $pebble-dark;
-    border: 2px solid $pebble-dark;
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px $pebble-dark;
+    @include tab-border($pebble-dark);
     color: black;
 }
 
 .no-border-inactive {
+    @extend %tab-theme;
     background-color: hsl(184, 5%, 95%);
-    border: 2px solid hsl(184, 5%, 95%);
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px hsl(184, 5%, 95%);
+    @include tab-border(hsl(184, 5%, 95%));
     color: slategrey;
 }
 
 .no-border-inactive:hover {
     background-color: $pebble-medium;
-    border: 2px solid $pebble-medium;
-    border-bottom: none;
-    box-shadow: inset 0 0 0 4px $pebble-medium;
+    @include tab-border($pebble-medium);
     color: black;
 }

--- a/tests/test_tabs.ts
+++ b/tests/test_tabs.ts
@@ -46,17 +46,56 @@ describe('Tabs tests', () => {
         const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
         expect(tabs.exists()).toEqual(true);
 
-        console.log(tabs.html());
         expect(tabs.find({ref: 'tab_1'}).isEmpty()).toEqual(true);
         expect(tabs.find({ref: 'active-tab-body'}).isEmpty()).toEqual(true);
     });
 
     test('Tab header has bare text', () => {
-       fail();
+        const component = {
+            template:  `<tabs ref="tabs">
+                            <tab>
+                                <tab-header ref="text_tab_header">
+                                    Spam
+                                </tab-header>
+                                <template slot="body">
+                                    Body
+                                </template>
+                            </tab>
+                        </tabs>`,
+            components: {
+                'tab': Tab,
+                'tabs': Tabs
+            }
+        };
+
+        const wrapper = mount(component);
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
+
+        expect(tabs.find({ref: 'text_tab_header'}).text()).toEqual('Spam');
     });
 
     test('Tab header has html', () => {
-       fail();
+        const component = {
+            template:  `<tabs ref="tabs">
+                          <tab>
+                            <tab-header ref="text_tab_header">
+                              <div>Spam</div>
+                            </tab-header>
+                            <template slot="body">
+                              Body
+                            </template>
+                          </tab>
+                        </tabs>`,
+            components: {
+                'tab': Tab,
+                'tabs': Tabs
+            }
+        };
+
+        const wrapper = mount(component);
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
+
+        expect(tabs.find({ref: 'text_tab_header'}).text()).toEqual('Spam');
     });
 
     // --------------------------------------------------------------------------------------------

--- a/tests/test_tabs.ts
+++ b/tests/test_tabs.ts
@@ -4,6 +4,7 @@ import { config, mount, Wrapper } from '@vue/test-utils';
 import Component from 'vue-class-component';
 
 import Tab from '@/components/tabs/tab.vue';
+import TabHeader from '@/components/tabs/tab_header.vue';
 import Tabs from '@/components/tabs/tabs.vue';
 
 beforeAll(() => {
@@ -50,18 +51,21 @@ describe('Tabs tests', () => {
         expect(tabs.find({ref: 'active-tab-body'}).isEmpty()).toEqual(true);
     });
 
+    // --------------------------------------------------------------------------------------------
+
     test('Tab header has bare text', () => {
         const component = {
-            template:  `<tabs ref="tabs">
-                            <tab>
-                                <tab-header ref="text_tab_header">
-                                    Spam
-                                </tab-header>
-                                <template slot="body">
-                                    Body
-                                </template>
-                            </tab>
-                        </tabs>`,
+            template:  `
+                <tabs ref="tabs">
+                  <tab>
+                    <tab-header ref="text_tab_header">
+                      Spam
+                    </tab-header>
+                    <template slot="body">
+                      Body
+                    </template>
+                  </tab>
+                </tabs>`,
             components: {
                 'tab': Tab,
                 'tabs': Tabs
@@ -74,18 +78,21 @@ describe('Tabs tests', () => {
         expect(tabs.find({ref: 'text_tab_header'}).text()).toEqual('Spam');
     });
 
+    // --------------------------------------------------------------------------------------------
+
     test('Tab header has html', () => {
         const component = {
-            template:  `<tabs ref="tabs">
-                          <tab>
-                            <tab-header ref="text_tab_header">
-                              <div>Spam</div>
-                            </tab-header>
-                            <template slot="body">
-                              Body
-                            </template>
-                          </tab>
-                        </tabs>`,
+            template:  `
+                <tabs ref="tabs">
+                  <tab>
+                    <tab-header ref="html_text_header">
+                      <div>Spam</div>
+                    </tab-header>
+                    <template slot="body">
+                      Body
+                    </template>
+                  </tab>
+                </tabs>`,
             components: {
                 'tab': Tab,
                 'tabs': Tabs
@@ -95,7 +102,174 @@ describe('Tabs tests', () => {
         const wrapper = mount(component);
         const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.find({ref: 'text_tab_header'}).text()).toEqual('Spam');
+        expect(tabs.find({ref: 'html_text_header'}).text()).toEqual('Spam');
+    });
+
+    // --------------------------------------------------------------------------------------------
+
+    test('tab-header given string class', async () => {
+        const component = {
+            template:  `
+                <tabs ref="tabs">
+                  <tab>
+                    <tab-header ref="header" class="spam">
+                      <div>Spam</div>
+                    </tab-header>
+                    <template slot="body">
+                      Body
+                    </template>
+                  </tab>
+                </tabs>`,
+            components: {
+                'tab': Tab,
+                'tabs': Tabs
+            }
+        };
+
+        const wrapper = mount(component);
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
+
+        let header = tabs.find({ref: 'header'});
+        expect(header.classes()).toContain('spam');
+    });
+
+    test('tab-header given object class info', async () => {
+        const component = {
+            template:  `
+                <tabs ref="tabs">
+                  <tab>
+                    <tab-header ref="header" :class="{spam: true}">
+                      Header
+                    </tab-header>
+                    <template slot="body">
+                      Body
+                    </template>
+                  </tab>
+                </tabs>`,
+            components: {
+                'tab': Tab,
+                'tabs': Tabs
+            }
+        };
+
+        const wrapper = mount(component);
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
+
+        let header = tabs.find({ref: 'header'});
+        expect(header.classes()).toContain('spam');
+    });
+
+    test('tab-header given class array', async () => {
+        const component = {
+            template:  `
+                <tabs ref="tabs">
+                  <tab>
+                    <tab-header ref="header" :class="['spam']">
+                      Header
+                    </tab-header>
+                    <template slot="body">
+                      Body
+                    </template>
+                  </tab>
+                </tabs>`,
+            components: {
+                'tab': Tab,
+                'tabs': Tabs
+            }
+        };
+
+        const wrapper = mount(component);
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
+
+        let header = tabs.find({ref: 'header'});
+        expect(header.classes()).toContain('spam');
+    });
+
+    test('tab-header has non-click event handler', async () => {
+        const component = {
+            template:  `
+                <tabs ref="tabs">
+                  <tab>
+                    <tab-header ref="header" @hover.native="hovered = true">
+                      Header
+                    </tab-header>
+                    <template slot="body">
+                      Body
+                    </template>
+                  </tab>
+                </tabs>`,
+            components: {
+                'tab': Tab,
+                'tabs': Tabs,
+                'tab-header': TabHeader
+            },
+            data: () => {
+                return {
+                    hovered: false
+                };
+            }
+        };
+
+        const wrapper = mount(component);
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
+
+        expect(wrapper.vm.$data.hovered).toBe(false);
+
+        let header = tabs.find({ref: 'header'});
+        header.trigger('hover');
+
+        expect(wrapper.vm.$data.hovered).toBe(true);
+    });
+
+    test('tab-header explicitly registered in parent', async () => {
+        const component = {
+            template:  `
+                <tabs ref="tabs">
+                  <tab>
+                    <tab-header ref="header">
+                      Spam
+                    </tab-header>
+                    <template slot="body">
+                      Body
+                    </template>
+                  </tab>
+                </tabs>`,
+            components: {
+                'tab': Tab,
+                'tab-header': TabHeader,
+                'tabs': Tabs
+            }
+        };
+
+        const wrapper = mount(component);
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
+
+        expect(tabs.find({ref: 'header'}).text()).toEqual('Spam');
+    });
+
+    test('tab-header not-explicitly registered in parent', async () => {
+        const component = {
+            template:  `
+                <tabs ref="tabs">
+                  <tab>
+                    <tab-header ref="header">
+                      Spam
+                    </tab-header>
+                    <template slot="body">
+                      Body
+                    </template>
+                  </tab>
+                </tabs>`,
+            components: {
+                'tab': Tab,
+                'tabs': Tabs
+            }
+        };
+
+        const wrapper = mount(component);
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
+
+        expect(tabs.find({ref: 'header'}).text()).toEqual('Spam');
     });
 
     // --------------------------------------------------------------------------------------------

--- a/tests/test_tabs.ts
+++ b/tests/test_tabs.ts
@@ -92,11 +92,11 @@ describe('Tabs tests', () => {
 
         expect(tabs.vm.active_tab_index).toEqual(0);
 
-        let active_headers = tabs.findAll(tabs.vm.tab_active_class);
+        let active_headers = tabs.findAll('.' + tabs.vm.tab_active_class);
         expect(active_headers.length).toBe(1);
         expect(active_headers.at(0).text()).toEqual('Tab 1');
 
-        expect(tabs.findAll(tabs.vm.tab_inactive_class).length).toBe(1);
+        expect(tabs.findAll('.' + tabs.vm.tab_inactive_class).length).toBe(1);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
@@ -140,11 +140,11 @@ describe('Tabs tests', () => {
 
         expect(tabs.vm.active_tab_index).toEqual(1);
 
-        let active_headers = tabs.findAll(tabs.vm.tab_active_class);
+        let active_headers = tabs.findAll('.' + tabs.vm.tab_active_class);
         expect(active_headers.length).toBe(1);
         expect(active_headers.at(0).text()).toEqual('Tab 2');
 
-        expect(tabs.findAll(tabs.vm.tab_inactive_class).length).toBe(1);
+        expect(tabs.findAll('.' + tabs.vm.tab_inactive_class).length).toBe(1);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 2 body');
@@ -199,11 +199,11 @@ describe('Tabs tests', () => {
 
         expect(tabs.vm.active_tab_index).toEqual(1);
 
-        let active_headers = tabs.findAll(tabs.vm.tab_active_class);
+        let active_headers = tabs.findAll('.' + tabs.vm.tab_active_class);
         expect(active_headers.length).toBe(1);
         expect(active_headers.at(0).text()).toEqual('Tab 2');
 
-        expect(tabs.findAll(tabs.vm.tab_inactive_class).length).toBe(2);
+        expect(tabs.findAll('.' + tabs.vm.tab_inactive_class).length).toBe(2);
 
         expect(active_body.text()).toEqual('Tab 2 body');
     });
@@ -676,6 +676,7 @@ describe('Tabs tests', () => {
         const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
         expect(tabs.find('#tab_header').exists()).toEqual(true);
+        expect(tabs.text()).toContain('Tab 1');
         expect(tabs.find('#extra').exists()).toEqual(false);
     });
 

--- a/tests/test_tabs.ts
+++ b/tests/test_tabs.ts
@@ -30,9 +30,9 @@ describe('Tabs tests', () => {
     test('Empty tab header and body', () => {
         const component = {
             template:  `<tabs ref="tabs">
-  <tab ref="tab_1">
-    <template slot="header">
-    </template>
+  <tab>
+    <tab-header ref="tab_1">
+    </tab-header>
     <template slot="body">
     </template>
   </tab>
@@ -51,23 +51,31 @@ describe('Tabs tests', () => {
         expect(tabs.find({ref: 'active-tab-body'}).isEmpty()).toEqual(true);
     });
 
+    test('Tab header has bare text', () => {
+       fail();
+    });
+
+    test('Tab header has html', () => {
+       fail();
+    });
+
     // --------------------------------------------------------------------------------------------
 
     test('First tab selected by default', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 1 body
     </template>
   </tab>
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 2
-    </template>
+    </tab-header>
     <template slot="body">
       Tab 2 body
     </template>
@@ -100,17 +108,17 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs" v-model="selected_tab">
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 1 body
     </template>
   </tab>
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 2
-    </template>
+    </tab-header>
     <template slot="body">
       Tab 2 body
     </template>
@@ -148,25 +156,25 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 1 body
     </template>
   </tab>
-  <tab ref="tab_2">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_2">
       Tab 2
-    </template>
+    </tab-header>
     <template slot="body">
       Tab 2 body
     </template>
   </tab>
-  <tab ref="tab_3">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_3">
         Tab 3
-    </template>
+    </tab-header>
     <template slot="body">
         Tab 3 body
     </template>
@@ -206,17 +214,17 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 1 body
     </template>
   </tab>
-  <tab ref="tab_2" @click="datum += 1">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_2" @click.native="datum += 1">
       Tab 2
-    </template>
+    </tab-header>
     <template slot="body">
       Tab 2 body
     </template>
@@ -259,18 +267,18 @@ describe('Tabs tests', () => {
     test('Tab v-model binding', () => {
         const component = {
             template:  `<tabs ref="tabs" v-model="current_tab">
-  <tab ref="tab_1">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_1">
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 1 body
     </template>
   </tab>
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 2
-    </template>
+    </tab-header>
     <template slot="body">
       Tab 2 body
     </template>
@@ -316,18 +324,18 @@ describe('Tabs tests', () => {
     test('Active index off end selects last tab', () => {
         const component = {
             template:  `<tabs ref="tabs" v-model="current_tab">
-  <tab ref="tab_1">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_1">
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 1 body
     </template>
   </tab>
-  <tab ref="tab_2">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_2">
       Tab 2
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 2 body
     </template>
@@ -360,9 +368,9 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab v-for="val in tab_vals" :key="val" ref="tab_1">
-    <template slot="header">
+    <tab-header>
       Tab {{val}}
-    </template>
+    </tab-header>
     <template slot="body">
      Tab {{val}} body
     </template>
@@ -397,9 +405,9 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs" :value="1">
   <tab v-for="val in tab_vals" :key="val" ref="tab_1">
-    <template slot="header">
+    <tab-header>
       Tab {{val}}
-    </template>
+    </tab-header>
     <template slot="body">
      Tab {{val}} body
     </template>
@@ -434,9 +442,9 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs" :value="2">
   <tab v-for="val in tab_vals" :key="val" ref="tab_1">
-    <template slot="header">
+    <tab-header>
       Tab {{val}}
-    </template>
+    </tab-header>
     <template slot="body">
      Tab {{val}} body
     </template>
@@ -471,9 +479,9 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab v-for="val in tab_vals" :key="val" ref="tab_1">
-    <template slot="header">
+    <tab-header>
       Tab {{val}}
-    </template>
+    </tab-header>
     <template slot="body">
      Tab {{val}} body
     </template>
@@ -509,9 +517,9 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab v-for="val in tab_vals" :key="val" ref="tab_1">
-    <template slot="header">
+    <tab-header>
       Tab {{val}}
-    </template>
+    </tab-header>
     <template slot="body">
      Tab {{val}} body
     </template>
@@ -547,9 +555,9 @@ describe('Tabs tests', () => {
         @Component({
             template:  `<tabs ref="tabs" v-model="current_tab">
   <tab v-for="val in tab_vals" :key="val" ref="tab_1">
-    <template slot="header">
+    <tab-header>
       Tab {{val}}
-    </template>
+    </tab-header>
     <template slot="body">
      Tab {{val}} body
     </template>
@@ -588,10 +596,10 @@ describe('Tabs tests', () => {
     test('Non <tab> tag in <tabs> is discarded', () => {
         const component = {
             template:  `<tabs ref="tabs">
-  <tab ref="real_tab">
-    <template slot="header">
+  <tab>
+    <tab-header ref="real_tab">
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 1 body
     </template>
@@ -617,9 +625,9 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
       Tab 1 body
     </template>
@@ -647,9 +655,9 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab>
-    <template slot="header">
-      <div id="tab_header">Tab 1</div>
-    </template>
+    <tab-header id="tab_header">
+      Tab 1
+    </tab-header>
     <template slot="body">
       Tab 1 body
     </template>
@@ -664,10 +672,10 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
+
         const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
         expect(tabs.find('#tab_header').exists()).toEqual(true);
-        expect(tabs.find('#tab_header').text()).toContain('Tab 1');
         expect(tabs.find('#extra').exists()).toEqual(false);
     });
 
@@ -687,7 +695,7 @@ describe('Tabs tests', () => {
 
         expect(
             () => mount(component)
-        ).toThrow('Make sure <tab> elements have "header" and "body" slots');
+        ).toThrow('Make sure <tab> elements have <tab-header> element and "body" slot');
     });
 
     // --------------------------------------------------------------------------------------------
@@ -709,7 +717,7 @@ describe('Tabs tests', () => {
 
         expect(
             () => mount(component)
-        ).toThrow('Make sure <tab> elements have "header" and "body" slots');
+        ).toThrow('Make sure <tab> elements have <tab-header> element and "body" slot');
     });
 
     // --------------------------------------------------------------------------------------------
@@ -733,7 +741,7 @@ describe('Tabs tests', () => {
 
         expect(
             () => mount(component)
-        ).toThrow('Missing "header" slot in <tab>.');
+        ).toThrow('Missing "<tab-header>" tag in <tab>.');
     });
 
     // --------------------------------------------------------------------------------------------
@@ -758,7 +766,7 @@ describe('Tabs tests', () => {
 
         expect(
             () => mount(component)
-        ).toThrow('"header" slot must be a <template> tag.');
+        ).toThrow('Missing "<tab-header>" tag in <tab>.');
     });
 
     // --------------------------------------------------------------------------------------------
@@ -767,9 +775,9 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 1
-    </template>
+    </tab-header>
     <div>Extra</div>
   </tab>
 </tabs>`,
@@ -790,9 +798,9 @@ describe('Tabs tests', () => {
         const component = {
             template:  `<tabs ref="tabs">
   <tab>
-    <template slot="header">
+    <tab-header>
       Tab 1
-    </template>
+    </tab-header>
     <div slot="body">
       Tab 1 body
     </div>
@@ -816,18 +824,18 @@ describe('Tabs tests', () => {
             template:  `<tabs ref="tabs"
     tab_active_class="blue-theme-active"
     tab_inactive_class="blue-theme-inactive">
-  <tab ref="tab_1">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_1">
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 1 body
     </template>
   </tab>
-  <tab ref="tab_2">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_2">
       Tab 2
-    </template>
+    </tab-header>
     <template slot="body">
       Tab 2 body
     </template>
@@ -872,18 +880,18 @@ describe('Tabs tests', () => {
     test('Tab style resorts to default settings if no inputs are supplied', () => {
         const component = {
             template:  `<tabs ref="tabs">
-  <tab ref="tab_1">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_1">
       Tab 1
-    </template>
+    </tab-header>
     <template slot="body">
      Tab 1 body
     </template>
   </tab>
-  <tab ref="tab_2">
-    <template slot="header">
+  <tab>
+    <tab-header ref="tab_2">
       Tab 2
-    </template>
+    </tab-header>
     <template slot="body">
       Tab 2 body
     </template>

--- a/tests/test_tabs.ts
+++ b/tests/test_tabs.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 
-import { config, mount } from '@vue/test-utils';
+import { config, mount, Wrapper } from '@vue/test-utils';
 import Component from 'vue-class-component';
 
 import Tab from '@/components/tabs/tab.vue';
@@ -21,7 +21,7 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
         expect(tabs.isEmpty()).toEqual(true);
     });
 
@@ -43,7 +43,7 @@ describe('Tabs tests', () => {
             }
         };
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
         expect(tabs.exists()).toEqual(true);
 
         console.log(tabs.html());
@@ -80,15 +80,15 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
 
-        let active_headers = tabs.findAll('.active-tab-header');
+        let active_headers = tabs.findAll(tabs.vm.tab_active_class);
         expect(active_headers.length).toBe(1);
         expect(active_headers.at(0).text()).toEqual('Tab 1');
 
-        expect(tabs.findAll('.inactive-tab-header').length).toBe(1);
+        expect(tabs.findAll(tabs.vm.tab_inactive_class).length).toBe(1);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
@@ -128,15 +128,15 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
 
-        let active_headers = tabs.findAll('.active-tab-header');
+        let active_headers = tabs.findAll(tabs.vm.tab_active_class);
         expect(active_headers.length).toBe(1);
         expect(active_headers.at(0).text()).toEqual('Tab 2');
 
-        expect(tabs.findAll('.inactive-tab-header').length).toBe(1);
+        expect(tabs.findAll(tabs.vm.tab_inactive_class).length).toBe(1);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 2 body');
@@ -179,9 +179,9 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
@@ -189,13 +189,13 @@ describe('Tabs tests', () => {
         let tab_2 = tabs.find({ref: 'tab_2'});
         tab_2.trigger('click');
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
 
-        let active_headers = tabs.findAll('.active-tab-header');
+        let active_headers = tabs.findAll(tabs.vm.tab_active_class);
         expect(active_headers.length).toBe(1);
         expect(active_headers.at(0).text()).toEqual('Tab 2');
 
-        expect(tabs.findAll('.inactive-tab-header').length).toBe(2);
+        expect(tabs.findAll(tabs.vm.tab_inactive_class).length).toBe(2);
 
         expect(active_body.text()).toEqual('Tab 2 body');
     });
@@ -234,10 +234,10 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
         expect(wrapper.vm.$data.datum).toEqual(0);
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
@@ -246,7 +246,7 @@ describe('Tabs tests', () => {
         tab_2.trigger('click');
 
         expect(wrapper.vm.$data.datum).toEqual(1);
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
 
         expect(active_body.text()).toEqual('Tab 2 body');
 
@@ -288,9 +288,9 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
@@ -298,7 +298,7 @@ describe('Tabs tests', () => {
         // Set current_tab, active tab should change
         wrapper.setData({current_tab: 1});
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
 
         expect(active_body.text()).toEqual('Tab 2 body');
 
@@ -307,7 +307,7 @@ describe('Tabs tests', () => {
         tab_1.trigger('click');
 
         expect(active_body.text()).toEqual('Tab 1 body');
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
         expect(wrapper.vm.$data.current_tab).toEqual(0);
     });
 
@@ -345,9 +345,9 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
         expect(wrapper.vm.$data.current_tab).toEqual(1);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
@@ -380,14 +380,14 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
 
         wrapper.vm.$data.tab_vals.splice(0, 1);
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
         expect(active_body.text()).toEqual('Tab 2 body');
     });
 
@@ -417,14 +417,14 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 2 body');
 
         wrapper.vm.$data.tab_vals.splice(1, 1);
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
         expect(active_body.text()).toEqual('Tab 3 body');
     });
 
@@ -454,14 +454,14 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(2);
+        expect(tabs.vm.active_tab_index).toEqual(2);
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 3 body');
 
         wrapper.vm.$data.tab_vals.splice(2, 1);
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
         expect(active_body.text()).toEqual('Tab 2 body');
     });
 
@@ -491,16 +491,16 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
 
         wrapper.vm.$data.tab_vals.splice(1, 1);
 
         expect(active_body.text()).toEqual('Tab 1 body');
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
     });
 
     // --------------------------------------------------------------------------------------------
@@ -529,16 +529,16 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
 
         wrapper.vm.$data.tab_vals.push(4);
 
         expect(active_body.text()).toEqual('Tab 1 body');
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
     });
 
     // --------------------------------------------------------------------------------------------
@@ -571,16 +571,16 @@ describe('Tabs tests', () => {
         }
 
         const wrapper = mount(WrapperComponent);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
 
         wrapper.vm.add_tab();
 
         expect(active_body.text()).toEqual('Tab 4 body');
-        expect(tabs.vm.$data.active_tab_index).toEqual(3);
+        expect(tabs.vm.active_tab_index).toEqual(3);
     });
 
     // --------------------------------------------------------------------------------------------
@@ -606,7 +606,7 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
         expect(tabs.find({ref: 'real_tab'}).exists()).toEqual(true);
         expect(tabs.find('#bad').exists()).toEqual(false);
     });
@@ -634,7 +634,7 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
         expect(tabs.text()).toContain('Tab 1');
         expect(tabs.text()).toContain('Tab 1 body');
@@ -664,7 +664,7 @@ describe('Tabs tests', () => {
         };
 
         const wrapper = mount(component);
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
         expect(tabs.find('#tab_header').exists()).toEqual(true);
         expect(tabs.find('#tab_header').text()).toContain('Tab 1');
@@ -841,13 +841,13 @@ describe('Tabs tests', () => {
 
         const wrapper = mount(component);
 
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
-        expect(tabs.vm.$data.tab_active_theme).toBe("blue-theme-active");
+        expect(tabs.vm.tab_active_class).toBe("blue-theme-active");
 
-        expect(tabs.vm.$data.tab_inactive_theme).toBe("blue-theme-inactive");
+        expect(tabs.vm.tab_inactive_class).toBe("blue-theme-inactive");
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
@@ -862,7 +862,7 @@ describe('Tabs tests', () => {
         expect(tab_2.classes()).toContain("blue-theme-active");
         expect(tab_1.classes()).toContain("blue-theme-inactive");
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
 
         expect(active_body.text()).toEqual('Tab 2 body');
     });
@@ -897,15 +897,15 @@ describe('Tabs tests', () => {
 
         const wrapper = mount(component);
 
-        const tabs = wrapper.find({ref: 'tabs'});
+        const tabs = <Wrapper<Tabs>> wrapper.find({ref: 'tabs'});
 
         console.log(tabs.html());
 
-        expect(tabs.vm.$data.tab_active_theme).toBe("white-theme-active");
+        expect(tabs.vm.tab_active_class).toBe("white-theme-active");
 
-        expect(tabs.vm.$data.tab_inactive_theme).toBe("white-theme-inactive");
+        expect(tabs.vm.tab_inactive_class).toBe("white-theme-inactive");
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(0);
+        expect(tabs.vm.active_tab_index).toEqual(0);
 
         let active_body = tabs.find({ref: 'active-tab-body'});
         expect(active_body.text()).toEqual('Tab 1 body');
@@ -920,7 +920,7 @@ describe('Tabs tests', () => {
         expect(tab_2.classes()).toContain("white-theme-active");
         expect(tab_1.classes()).toContain("white-theme-inactive");
 
-        expect(tabs.vm.$data.active_tab_index).toEqual(1);
+        expect(tabs.vm.active_tab_index).toEqual(1);
 
         expect(active_body.text()).toEqual('Tab 2 body');
     });


### PR DESCRIPTION
Instead of a named slot, tab headers are now specified with a `<tab-header>` tag. Any styling added to this element is directly applied to the underlying html that comprises the header.