### PR TITLE
97 update multi file viewer tabs to use overflow: hidden

### DIFF
--- a/src/components/hello_world.vue
+++ b/src/components/hello_world.vue
@@ -1,22 +1,22 @@
 <template>
   <div>
-    <!--<ButtonDemo></ButtonDemo>-->
-    <!--<ColorPaletteDemo></ColorPaletteDemo>-->
-    <!--<ContextMenuDemo></ContextMenuDemo>-->
-    <!--<CourseListDemo></CourseListDemo>-->
-    <!--<DiffDemo></DiffDemo>-->
-    <!--<DropdownDemo></DropdownDemo>-->
-    <!--<DropdownTypeaheadDemo></DropdownTypeaheadDemo>-->
-    <!--<ModalDemo></ModalDemo>-->
-    <!--<FileUploadDemo></FileUploadDemo>-->
-    <!--<LoadingIconDemo></LoadingIconDemo>-->
+    <ButtonDemo></ButtonDemo>
+    <ColorPaletteDemo></ColorPaletteDemo>
+    <ContextMenuDemo></ContextMenuDemo>
+    <CourseListDemo></CourseListDemo>
+    <DiffDemo></DiffDemo>
+    <DropdownDemo></DropdownDemo>
+    <DropdownTypeaheadDemo></DropdownTypeaheadDemo>
+    <ModalDemo></ModalDemo>
+    <FileUploadDemo></FileUploadDemo>
+    <LoadingIconDemo></LoadingIconDemo>
     <MultiFileViewerDemo></MultiFileViewerDemo>
     <TabsDemo></TabsDemo>
-    <!--<TooltipDemo></TooltipDemo>-->
-    <!--<ToggleDemo></ToggleDemo>-->
-    <!--<ViewFileDemo></ViewFileDemo>-->
-    <!--<ValidatedInputDemo></ValidatedInputDemo>-->
-    <!--<ValidatedFormDemo></ValidatedFormDemo>-->
+    <TooltipDemo></TooltipDemo>
+    <ToggleDemo></ToggleDemo>
+    <ViewFileDemo></ViewFileDemo>
+    <ValidatedInputDemo></ValidatedInputDemo>
+    <ValidatedFormDemo></ValidatedFormDemo>
   </div>
 </template>
 

--- a/src/components/hello_world.vue
+++ b/src/components/hello_world.vue
@@ -1,22 +1,22 @@
 <template>
   <div>
-    <ButtonDemo></ButtonDemo>
-    <ColorPaletteDemo></ColorPaletteDemo>
-    <ContextMenuDemo></ContextMenuDemo>
-    <CourseListDemo></CourseListDemo>
-    <DiffDemo></DiffDemo>
-    <DropdownDemo></DropdownDemo>
-    <DropdownTypeaheadDemo></DropdownTypeaheadDemo>
-    <ModalDemo></ModalDemo>
-    <FileUploadDemo></FileUploadDemo>
-    <LoadingIconDemo></LoadingIconDemo>
+    <!--<ButtonDemo></ButtonDemo>-->
+    <!--<ColorPaletteDemo></ColorPaletteDemo>-->
+    <!--<ContextMenuDemo></ContextMenuDemo>-->
+    <!--<CourseListDemo></CourseListDemo>-->
+    <!--<DiffDemo></DiffDemo>-->
+    <!--<DropdownDemo></DropdownDemo>-->
+    <!--<DropdownTypeaheadDemo></DropdownTypeaheadDemo>-->
+    <!--<ModalDemo></ModalDemo>-->
+    <!--<FileUploadDemo></FileUploadDemo>-->
+    <!--<LoadingIconDemo></LoadingIconDemo>-->
     <MultiFileViewerDemo></MultiFileViewerDemo>
     <TabsDemo></TabsDemo>
-    <TooltipDemo></TooltipDemo>
-    <ToggleDemo></ToggleDemo>
-    <ViewFileDemo></ViewFileDemo>
-    <ValidatedInputDemo></ValidatedInputDemo>
-    <ValidatedFormDemo></ValidatedFormDemo>
+    <!--<TooltipDemo></TooltipDemo>-->
+    <!--<ToggleDemo></ToggleDemo>-->
+    <!--<ViewFileDemo></ViewFileDemo>-->
+    <!--<ValidatedInputDemo></ValidatedInputDemo>-->
+    <!--<ValidatedFormDemo></ValidatedFormDemo>-->
   </div>
 </template>
 

--- a/src/components/multi_file_viewer.vue
+++ b/src/components/multi_file_viewer.vue
@@ -7,25 +7,21 @@
        <tab v-for="(open_file, index) of files_currently_viewing">
          <tab-header @click.native="active_tab_index = index">
            <div class="tab-header">
-             <p class="tab-label"> {{ open_file.name }} </p>
+             <p class="tab-label">{{ open_file.name }}</p>
              <i class="fas fa-times close-x"
                 @click="$event.stopPropagation(); remove_from_viewing(index)"></i>
            </div>
          </tab-header>
-
          <template slot="body">
            <div class="tab-body">
-
              <view-file
                ref="view_file_component"
                :filename="open_file.name"
                :file_contents="open_file.content"
                :view_file_height="height_of_view_file">
              </view-file>
-
            </div>
          </template>
-
        </tab>
     </tabs>
   </div>
@@ -45,7 +41,7 @@
   }
 
   @Component({
-    components: { Tab, Tabs, ViewFile }
+    components: { Tab, Tabs, TabHeader, ViewFile }
   })
   export default class MultiFileViewer extends Vue {
 
@@ -78,19 +74,22 @@
 
 <style scoped lang="scss">
 @import '@/styles/colors.scss';
+@import url('https://fonts.googleapis.com/css?family=Quicksand');
+$current-lang-choice: "Quicksand";
 
 .close-x {
-  color: hsl(0.61, 89%, 71%);
+  background-color: inherit;
+  color: hsl(220, 20%, 85%);
   cursor: pointer;
-  display: inline-block;
-  margin-bottom: 0;
+  font-size: 16px;
+  padding: 12px 15px;
   position: absolute;
-  right: 15px;
-  top: 12px;
+  right: 6px;
+  top: 5.5px;
 }
 
 .close-x:hover {
-  color: hsl(0.61, 85%, 60%);
+  color: hsl(220, 20%, 55%);
 }
 
 .tab-body {
@@ -98,19 +97,33 @@
   border: 2px solid hsl(210, 11%, 90%);
   bottom: 0;
   color: #24292e;
-  min-width: 800px;
   position: relative;
 }
 
 .tab-header {
   margin: 0;
+  background-color: inherit;
 }
 
 .tab-label {
   display: inline-block;
-  font-family: "Helvetica Neue", Helvetica;
+  font-family: $current-lang-choice;
   margin: 0;
   padding-right: 25px;
+}
+
+.tab-header {
+  overflow: hidden;
+}
+
+@media only screen and (min-width: 481px) {
+  .close-x {
+    background-color: inherit;
+    font-size: inherit;
+    padding: 3px 5px;
+    right: 8px;
+    top: 10px;
+  }
 }
 
 </style>

--- a/src/components/multi_file_viewer.vue
+++ b/src/components/multi_file_viewer.vue
@@ -7,7 +7,7 @@
        <tab v-for="(open_file, index) of files_currently_viewing">
          <tab-header @click.native="active_tab_index = index">
            <div class="tab-header">
-             <p class="tab-label">{{ open_file.name }}</p>
+             <p class="tab-label">{{open_file.name}}</p>
              <i class="fas fa-times close-x"
                 @click="$event.stopPropagation(); remove_from_viewing(index)"></i>
            </div>

--- a/src/components/multi_file_viewer.vue
+++ b/src/components/multi_file_viewer.vue
@@ -101,8 +101,9 @@ $current-lang-choice: "Quicksand";
 }
 
 .tab-header {
-  margin: 0;
   background-color: inherit;
+  margin: 0;
+  overflow: hidden;
 }
 
 .tab-label {
@@ -110,10 +111,6 @@ $current-lang-choice: "Quicksand";
   font-family: $current-lang-choice;
   margin: 0;
   padding-right: 25px;
-}
-
-.tab-header {
-  overflow: hidden;
 }
 
 @media only screen and (min-width: 481px) {

--- a/src/demos/multi_file_viewer_demo.vue
+++ b/src/demos/multi_file_viewer_demo.vue
@@ -101,7 +101,7 @@ export default class MultiFileViewerDemo extends Vue {
 }
 
 .multi-file-viewer-demo {
-  padding: 20px 0;
+  padding: 20px 15px;
 }
 
 </style>


### PR DESCRIPTION
Fixes #97. It's not possible to apply overflow: hidden to the tab-active/inactive classes applied to the Tabs component. 