### PR TITLE
117 switch to sinon for mocking context menu

### DIFF
--- a/src/components/context_menu.vue
+++ b/src/components/context_menu.vue
@@ -16,7 +16,7 @@
 <script lang="ts">
 
   import ContextMenuItem from '@/components/context_menu_item.vue';
-  import { Component, Prop, Vue } from 'vue-property-decorator';
+  import { Component, Vue } from 'vue-property-decorator';
 
   @Component({
     components: {

--- a/src/components/context_menu/context_menu.vue
+++ b/src/components/context_menu/context_menu.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts">
 
-  import ContextMenuItem from '@/components/context_menu_item.vue';
+  import ContextMenuItem from '@/components/context_menu/context_menu_item.vue';
   import { Component, Vue } from 'vue-property-decorator';
 
   @Component({
@@ -26,8 +26,8 @@
   export default class ContextMenu extends Vue {
 
     private d_is_open = false;
-    private d_height_of_menu = 0;
-    private d_width_of_menu = 0;
+    d_height_of_menu = 0;
+    d_width_of_menu = 0;
 
     private wheel_event_handler!: (event: Event) => void;
 

--- a/src/components/context_menu/context_menu_item.vue
+++ b/src/components/context_menu/context_menu_item.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts">
-  import ContextMenu from '@/components/context_menu.vue';
+  import ContextMenu from '@/components/context_menu/context_menu.vue';
   import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
   @Component

--- a/src/demos/context_menu_demo.vue
+++ b/src/demos/context_menu_demo.vue
@@ -116,8 +116,8 @@
 </template>
 
 <script lang="ts">
-  import ContextMenu from '@/components/context_menu.vue';
-  import ContextMenuItem from '@/components/context_menu_item.vue';
+  import ContextMenu from '@/components/context_menu/context_menu.vue';
+  import ContextMenuItem from '@/components/context_menu/context_menu_item.vue';
   import { Component, Prop, Vue } from 'vue-property-decorator';
 
   @Component({

--- a/tests/test_context_menu.ts
+++ b/tests/test_context_menu.ts
@@ -4,7 +4,6 @@ import { config, mount } from '@vue/test-utils';
 import * as sinon from 'sinon';
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import { compile } from 'vue-template-compiler';
 
 beforeAll(() => {
     config.logModifiedComponents = false;
@@ -136,7 +135,6 @@ describe('ContextMenu tests', () => {
          wrapper.vm.$destroy();
     });
 
-
     test("Clicking on a context menu item closes the context menu",
          async () => {
         let wrapper = mount(WrapperComponent);
@@ -216,7 +214,6 @@ describe('ContextMenu tests', () => {
         expect((<HTMLElement> context_menu.$el).style.visibility).toBe("visible");
 
         let outside_input = wrapper.find('#outside');
-
         outside_input.trigger('click');
         outside_input.element.focus();
         await context_menu.$nextTick();
@@ -267,7 +264,7 @@ describe('ContextMenu tests', () => {
 
         expect(context_menu_item_1.emitted('context_menu_item_clicked')).not.toBeTruthy();
 
-        wrapper.vm.$data.is_disabled = false;
+        wrapper.vm.is_disabled = false;
         context_menu_item_1.trigger('click');
 
         expect(context_menu_item_1.emitted().context_menu_item_clicked.length).toBe(1);
@@ -319,7 +316,7 @@ describe('ContextMenu tests', () => {
         await context_menu.$nextTick();
 
         let context_menu_item_1 = wrapper.find({ref: 'item_1'});
-        expect(context_menu_item_1.vm.$data.d_disabled).toBe(true);
+        expect(context_menu_item_1.vm.d_disabled).toBe(true);
 
         context_menu_item_1.trigger('click');
         await context_menu.$nextTick();
@@ -477,23 +474,18 @@ describe('ContextMenu tests', () => {
     test("Scrolling via wheel event is disallowed while the context menu is open",
          () => {
         let wrapper = mount(WrapperComponent, {attachToDocument: true});
-
         let context_menu_area = wrapper.find('.context-menu-area');
 
-        let num_wheel_events = 0;
-        let handle_wheel_event = () => {
-            ++num_wheel_events;
-        };
-
+        let handle_wheel_event = sinon.fake();
         context_menu_area.element.addEventListener('wheel', handle_wheel_event);
 
         context_menu_area.trigger('wheel');
-        expect(num_wheel_events).toEqual(1);
+        expect(handle_wheel_event.calledOnce).toBe(true);
 
         context_menu_area.trigger('click');
 
         context_menu_area.trigger('wheel');
-        expect(num_wheel_events).toEqual(1);
+        expect(handle_wheel_event.calledOnce).toBe(true);
 
         wrapper.destroy();
     });

--- a/tests/test_context_menu.ts
+++ b/tests/test_context_menu.ts
@@ -1,5 +1,5 @@
-import ContextMenu from '@/components/context_menu.vue';
-import ContextMenuItem from '@/components/context_menu_item.vue';
+import ContextMenu from '@/components/context_menu/context_menu.vue';
+import ContextMenuItem from '@/components/context_menu/context_menu_item.vue';
 import { config, mount } from '@vue/test-utils';
 import * as sinon from 'sinon';
 import Vue from 'vue';
@@ -132,7 +132,7 @@ describe('ContextMenu tests', () => {
          expect(context_menu_item_1.$el.classList).toContain('first-child');
          expect(context_menu_item_3.$el.classList).toContain('last-child');
 
-         wrapper.vm.$destroy();
+         wrapper.destroy();
     });
 
     test("Clicking on a context menu item closes the context menu",
@@ -156,7 +156,7 @@ describe('ContextMenu tests', () => {
         expect((<HTMLElement> context_menu.$el).style.visibility).toBe('hidden');
         expect(context_menu.menu_is_open).toBe(false);
 
-        wrapper.vm.$destroy();
+        wrapper.destroy();
     });
 
     test("Context Menu Items in a Context Menu can handle click events differently",
@@ -199,7 +199,7 @@ describe('ContextMenu tests', () => {
 
         expect(greeting.text()).toBe('Boo!');
 
-        wrapper.vm.$destroy();
+        wrapper.destroy();
     });
 
     test("Clicking inside the context menu area makes the menu visible, and clicking" +
@@ -220,7 +220,7 @@ describe('ContextMenu tests', () => {
 
         expect((<HTMLElement> context_menu.$el).style.visibility).toBe("hidden");
 
-        wrapper.vm.$destroy();
+        wrapper.destroy();
     });
 
     test("toggle disabled property on context menu item",
@@ -269,7 +269,7 @@ describe('ContextMenu tests', () => {
 
         expect(context_menu_item_1.emitted().context_menu_item_clicked.length).toBe(1);
 
-        wrapper.vm.$destroy();
+        wrapper.destroy();
     });
 
     test("parent component is not notified when disabled context menu items are clicked",
@@ -315,15 +315,15 @@ describe('ContextMenu tests', () => {
         context_menu_area.trigger('click');
         await context_menu.$nextTick();
 
-        let context_menu_item_1 = wrapper.find({ref: 'item_1'});
-        expect(context_menu_item_1.vm.d_disabled).toBe(true);
+        let context_menu_item_1 = <ContextMenuItem> wrapper.find({ref: 'item_1'}).vm;
+        expect(context_menu_item_1.d_disabled).toBe(true);
 
-        context_menu_item_1.trigger('click');
+        wrapper.find({ref: 'item_1'}).trigger('click');
         await context_menu.$nextTick();
 
         expect(greeting.element.style.color).toBe("black");
 
-        wrapper.vm.$destroy();
+        wrapper.destroy();
     });
 
     test("When a user clicks too near to the right edge, the positioning of the " +
@@ -382,8 +382,7 @@ describe('ContextMenu tests', () => {
         expect(number_new_left).toBeLessThan(798);
 
         sinon.restore();
-
-        wrapper.vm.$destroy();
+        wrapper.destroy();
     });
 
     test("When a user clicks too near to the bottom edge, the positioning of the " +
@@ -441,8 +440,7 @@ describe('ContextMenu tests', () => {
         expect(number_new_top).toBeLessThan(498);
 
         sinon.restore();
-
-        wrapper.vm.$destroy();
+        wrapper.destroy();
      });
 
     test('Default menu slot', () => {
@@ -504,7 +502,6 @@ describe('ContextMenu tests', () => {
         await context_menu_component.$nextTick();
 
         expect(context_menu_component.menu_is_open).toBe(false);
-
-        wrapper.vm.$destroy();
+        wrapper.destroy();
     });
 });


### PR DESCRIPTION
Fixes a portion of #117. Added sinon to the ContextMenu tests.