### PR TITLE
Added a test for switching to the my submissions tab on submit.

### DIFF
--- a/src/components/project_view/project_view.vue
+++ b/src/components/project_view/project_view.vue
@@ -59,7 +59,7 @@
                             :course="course">
         </group-registration>
         <submit v-else
-                @submitted="set_current_tab('my_submissions')"
+                @submitted="on_submit"
                 :course="course" :project="project" :group="group"></submit>
       </div>
 
@@ -233,6 +233,11 @@ export default class ProjectView extends Vue implements GroupObserver {
     return !this.d_globals.user_roles.is_handgrader
            || this.d_globals.user_roles.is_student
            || this.d_globals.user_roles.is_staff;
+  }
+
+  on_submit() {
+    this.set_current_tab('my_submissions');
+    return this.group!.refresh();
   }
 
   update_group_changed(group: Group): void {}

--- a/src/components/submission_list/submission_list.vue
+++ b/src/components/submission_list/submission_list.vue
@@ -173,9 +173,20 @@ export default class SubmissionList extends Vue implements SubmissionObserver, C
     await this.get_ultimate_submission();
 
     if (this.d_submissions.length !== 0) {
-      this.d_selected_submission = (
-        this.d_ultimate_submission !== null ? this.d_ultimate_submission : this.d_submissions[0]
+      let submission_being_graded = this.d_submissions.find(
+        submission => submission.status === GradingStatus.received
+                      || submission.status === GradingStatus.queued
+                      || submission.status === GradingStatus.being_graded
       );
+      if (submission_being_graded !== undefined) {
+        this.d_selected_submission = submission_being_graded;
+      }
+      else if (this.d_ultimate_submission !== null) {
+        this.d_selected_submission = this.d_ultimate_submission;
+      }
+      else {
+        this.d_selected_submission = this.d_submissions[0];
+      }
     }
 
     if (this.plain_submissions_poller !== null) {

--- a/tests/data_utils.ts
+++ b/tests/data_utils.ts
@@ -247,7 +247,9 @@ export function make_submission_with_results(
     submission_args: Partial<Submission> = {},
     result_args: Partial<SubmissionResultFeedback> = {}
 ): SubmissionWithResults {
-    let submission = make_submission(group, submission_args);
+    let args = submission_args.status === undefined
+               ? {...submission_args, status: GradingStatus.finished_grading} : submission_args;
+    let submission = make_submission(group, args);
     let result_defaults = {
         pk: submission.pk,
         total_points: 0,

--- a/tests/test_project_view/test_project_view.ts
+++ b/tests/test_project_view/test_project_view.ts
@@ -162,6 +162,18 @@ describe('Submit tab tests', () => {
         expect(wrapper.find({name: 'Submit'}).exists()).toBe(true);
         expect(wrapper.find({ref: 'submit_tab'}).exists()).toBe(true);
     });
+
+    test('My Submissions tab selected after submission', async () => {
+        let refresh_stub = sinon.stub(group, 'refresh');
+        wrapper = managed_mount(ProjectView, {mocks: get_router_mocks()});
+        expect(await wait_for_load(wrapper)).toBe(true);
+
+        expect(refresh_stub.callCount).toEqual(0);
+        wrapper.find({name: 'Submit'}).vm.$emit('submitted');
+        await wrapper.vm.$nextTick();
+        expect(wrapper.vm.d_current_tab).toEqual('my_submissions');
+        expect(refresh_stub.callCount).toEqual(1);
+    });
 });
 
 describe('My submissions tab tests', () => {
@@ -341,7 +353,7 @@ describe('Tab selection and lazy loading tests', ()  => {
         expect(await wait_for_load(wrapper)).toBe(true);
         expect(wrapper.find({name: 'Submit'}).exists()).toBe(true);
         expect(wrapper.find({name: 'SubmissionList'}).exists()).toBe(false);
-        // expect(wrapper.find({name: 'StudentLookup'}).exists()).toBe(false);
+        expect(wrapper.find({name: 'StudentLookup'}).exists()).toBe(false);
         expect(wrapper.find({name: 'HandgradingContainer'}).exists()).toBe(false);
         expect(wrapper.find({name: 'Handgrading'}).exists()).toBe(false);
     });

--- a/tests/test_project_view/test_submission_detail/test_submission_detail.ts
+++ b/tests/test_project_view/test_submission_detail/test_submission_detail.ts
@@ -200,7 +200,8 @@ describe('SubmissionDetail tests', () => {
     });
 
     test('grading status section', async () => {
-        submission_with_results = data_ut.make_submission_with_results(group);
+        submission_with_results = data_ut.make_submission_with_results(
+            group, {status: ag_cli.GradingStatus.received});
         get_submission_result_stub.returns(Promise.resolve(submission_with_results.results));
 
         wrapper = make_wrapper(submission_with_results, course, group, false, globals);


### PR DESCRIPTION
Refreshed the current group after submitting.
Made submission list initially load a received/queued/being graded submission if any before checking for ultimate submission or falling back on most recent.

Fixes #284 
Fixes #298 