### PR TITLE
Updated return code correctness logic to check whether return_code_co…

### DIFF
--- a/src/components/project_view/submission_detail/ag_suite_result.vue
+++ b/src/components/project_view/submission_detail/ag_suite_result.vue
@@ -161,10 +161,11 @@ export default class AGSuiteResult extends Vue {
     }
 
     let all_show_return_code_only = without_not_available.every(
-      (cmd_result) => cmd_result.actual_return_code !== null || cmd_result.timed_out!);
+      (cmd_result) => cmd_result.return_code_correct === null
+                      && (cmd_result.actual_return_code !== null || cmd_result.timed_out!));
 
     if (all_show_return_code_only) {
-        return CorrectnessLevel.info_only;
+      return CorrectnessLevel.info_only;
     }
 
     let all_correct = case_result.ag_test_command_results.every(

--- a/tests/test_project_view/test_submission_detail/test_ag_suite_result.ts
+++ b/tests/test_project_view/test_submission_detail/test_ag_suite_result.ts
@@ -579,7 +579,7 @@ describe('case_result_return_code_correctness tests', () => {
     });
 
     // Regression test for https://github.com/eecs-autograder/ag-website-vue/issues/376
-    test('Single-command test, only return code checked, all correct', async () => {
+    test('Single-command test, actual return code and correctness shown, all correct', async () => {
         let test_case = data_ut.make_ag_test_case(
             data_ut.make_ag_test_suite(group.project).pk
         );

--- a/tests/test_project_view/test_submission_detail/test_ag_suite_result.ts
+++ b/tests/test_project_view/test_submission_detail/test_ag_suite_result.ts
@@ -577,6 +577,33 @@ describe('case_result_return_code_correctness tests', () => {
             CorrectnessLevel.none_correct
         );
     });
+
+    // Regression test for https://github.com/eecs-autograder/ag-website-vue/issues/376
+    test('Single-command test, only return code checked, all correct', async () => {
+        let test_case = data_ut.make_ag_test_case(
+            data_ut.make_ag_test_suite(group.project).pk
+        );
+        let test_result = data_ut.make_ag_test_case_result_feedback(test_case.pk);
+
+        let return_code_correct_res = data_ut.make_ag_test_command_result_feedback(
+            data_ut.make_ag_test_command(test_case.pk).pk,
+            {
+                actual_return_code: 0,
+                return_code_correct: true,
+                return_code_points: 1,
+                return_code_points_possible: 1,
+            }
+        );
+
+        test_result.ag_test_command_results = [return_code_correct_res];
+
+        expect(wrapper.vm.case_result_return_code_correctness(test_result)).toEqual(
+            CorrectnessLevel.all_correct
+        );
+        expect(wrapper.vm.case_result_correctness(test_result)).toEqual(
+            CorrectnessLevel.all_correct
+        );
+    });
 });
 
 describe('case_result_output_correctness tests', () => {


### PR DESCRIPTION
…rrect is null when checking to see if correctness level is info only.

This fixes an issue where tests that only check return code were being flagged as info-only with pass/fail + exit status feedback.

Fixes #376 