### PR TITLE
Tweak image buid output reload logic.

### DIFF
--- a/src/components/sandbox_images/build_image_task_detail.vue
+++ b/src/components/sandbox_images/build_image_task_detail.vue
@@ -127,7 +127,7 @@ export default class BuildImageTaskDetail extends Vue {
   @Watch('build_task')
   on_build_task_change(
       new_task: BuildSandboxDockerImageTask, old_task: BuildSandboxDockerImageTask) {
-    if (new_task.status !== old_task.status) {
+    if (new_task.status !== old_task.status || new_task.status === BuildImageStatus.in_progress) {
       return this.load_output();
     }
   }

--- a/tests/test_sandbox_images/test_build_image_task_detail.ts
+++ b/tests/test_sandbox_images/test_build_image_task_detail.ts
@@ -102,7 +102,7 @@ test('Internal error status superuser', async () => {
     expect(wrapper.find('.internal-error-msg').text().trim()).toEqual(internal_error_msg);
 });
 
-test('Status change output loaded', async () => {
+test('Output re-loaded when status changes', async () => {
     let queued_task = deep_copy(build_task, ag_cli.BuildSandboxDockerImageTask);
     let wrapper = await make_wrapper(queued_task);
     expect(wrapper.findComponent({ref: 'output'}).exists()).toBe(false);


### PR DESCRIPTION
Output is refreshed if the tasks status changed or the task object has changed and its status is 'in_progress'.