### PR TITLE
Display a guessed timezone for all dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16262,6 +16262,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
+    "moment-timezone": {
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lodash": "^4.17.13",
     "minimatch": "^3.0.4",
     "moment": "^2.24.0",
+    "moment-timezone": "^0.5.31",
     "vue": "^2.6.10",
     "vue-class-component": "^7.0.0",
     "vue-property-decorator": "^8.0.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { Dictionary } from 'vue-router/types/router';
 
 import { Course } from 'ag-client-typescript';
 // @ts-ignore
-import moment from "moment";
+import moment from 'moment-timezone';
 
 export function sleep(seconds: number) {
     return new Promise(resolve => setTimeout(resolve, seconds * 1000));
@@ -111,13 +111,13 @@ export function get_query_param(query_params: Dictionary<string | string[]>, key
 
 export function format_datetime(datetime: string | null): string {
     if (datetime === null) {
-        return '--- --, ----, --:-- --';
+        return '--- --, ----, --:-- -- ---';
     }
-    return moment(datetime).format('MMMM DD, YYYY, hh:mm A');
+    return moment(datetime).tz(moment.tz.guess()).format('MMMM DD, YYYY, hh:mm A z');
 }
 
 export function format_datetime_short(datetime: string): string {
-    return moment(datetime).format("MMM DD, 'YY, hh:mm A");
+    return moment(datetime).tz(moment.tz.guess()).format("MMM DD, 'YY, hh:mm A z");
 }
 
 export function format_time(time: string | null): string {


### PR DESCRIPTION
Uses moment-timezone add-on to guess at the user's timezone, and then includes the guessed timezone in the formatted time.

The motivation for this change: now that most universities (particularly UofM) have increased async coursework, it is no longer reasonable to assume all students operate in the same timezone as the Autograder server. As a concrete example, a student in EECS 481 used up their submits not realizing the "daily submissions limit" applied to EDT.

Here is an example of views for students in various potential regions: 

<img width="1113" alt="Screen Shot 2020-10-29 at 4 04 47 PM" src="https://user-images.githubusercontent.com/16354853/97641634-b77f2600-1a19-11eb-84ef-6d7592a7f15c.png">

<img width="1189" alt="Screen Shot 2020-10-29 at 4 05 05 PM" src="https://user-images.githubusercontent.com/16354853/97641683-d67db800-1a19-11eb-8de5-bb452421ba78.png">

<img width="1135" alt="Screen Shot 2020-10-30 at 4 36 52 AM" src="https://user-images.githubusercontent.com/16354853/97641733-f1502c80-1a19-11eb-83b6-7b96fb182c4c.png">

Fixes #442 