### PR TITLE
Updated image build status message to notify user when the build failed because it timed out

### DIFF
--- a/src/components/sandbox_images/build_image_task_detail.vue
+++ b/src/components/sandbox_images/build_image_task_detail.vue
@@ -13,6 +13,11 @@
       </template>
       <template v-else-if="build_task.status === BuildImageStatus.failed">
         Build Failed
+        <div v-if="build_task.timed_out" class="explanation">
+          The build exceeded the time limit of 10 minutes. Please optimize
+          your build or use the strategy detailed
+          <a :href="tips_and_tricks_url">here.</a>
+        </div>
       </template>
       <template v-else-if="build_task.status === BuildImageStatus.image_invalid">
         Invalid Image
@@ -132,6 +137,9 @@ export default class BuildImageTaskDetail extends Vue {
   d_downloading_files = false;
 
   d_cancelling_build = false;
+
+  tips_and_tricks_url = 'https://eecs-autograder.github.io/autograder.io'
+                        + '/topics/custom_sandbox_images.html#tips-and-tricks';
 
   created() {
     return this.load_output();

--- a/src/components/sandbox_images/build_sandbox_image.vue
+++ b/src/components/sandbox_images/build_sandbox_image.vue
@@ -16,7 +16,7 @@
 
     <progress-bar
       class="progress-bar"
-      v-if="d_file_upload_progress !== null"
+      v-if="d_starting_build && d_file_upload_progress !== null"
       :progress="d_file_upload_progress"
     />
     <APIErrors ref="api_errors"></APIErrors>

--- a/tests/test_sandbox_images/test_build_image_task_detail.ts
+++ b/tests/test_sandbox_images/test_build_image_task_detail.ts
@@ -60,11 +60,22 @@ test('Done status', async () => {
     expect(wrapper.find('.status-info').text().trim()).toEqual('Success!');
 });
 
-test('Failed status', async () => {
+test('Failed status, no timeout', async () => {
     build_task.status = ag_cli.BuildImageStatus.failed;
     let wrapper = await make_wrapper();
     expect(wrapper.findComponent({ref: 'output'}).exists()).toBe(true);
     expect(wrapper.find('.status-info').text().trim()).toEqual('Build Failed');
+});
+
+test('Failed status and timed out', async () => {
+    build_task.status = ag_cli.BuildImageStatus.failed;
+    build_task.timed_out = true;
+    let wrapper = await make_wrapper();
+    expect(wrapper.findComponent({ref: 'output'}).exists()).toBe(true);
+    expect(wrapper.find('.status-info').text().trim()).toContain('Build Failed');
+    expect(wrapper.find('.status-info .explanation').text().trim()).toContain(
+        'The build exceeded the time limit'
+    );
 });
 
 test('Invalid image status', async () => {


### PR DESCRIPTION
Note that we're still using the same "build failed" icon regardless of whether the build timed out.

Fixes #446 