### PR TITLE
236 batch delete

### DIFF
--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -21,11 +21,13 @@
             <span class="sidebar-header-text"
                   v-if="!d_collapsed || current_filename === null">Uploaded Files</span>
           </div>
-          <button v-if="!d_collapsed && batch_mode"
-                  class="batch-delete-files-button red-button"
+          <button v-if="!d_collapsed"
+                  class="batch-delete-files-button"
+                  :class="{'red-button': batch_mode, 'gray-button': !batch_mode}"
+                  :disabled="!batch_mode"
                   @click.stop="request_batch_delete()"
           >
-            Delete
+            Batch Delete
           </button>
         </div>
 

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -27,7 +27,6 @@
             <button v-if="d_batch_mode" class="batch-delete-files-button red-button" @click.stop="request_batch_delete()">
               Delete
             </button>
-            <input class="batch-select-all-checkbox" type="checkbox" @click="batch_toggle_all()" />
           </div>
         </div>
 

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -21,8 +21,8 @@
                 v-if="!d_collapsed || current_filename === null">Uploaded Files</span>
           <button v-if="!d_collapsed"
                   class="batch-delete-files-button"
-                  :class="{'red-button': batch_mode, 'gray-button': !batch_mode}"
-                  :disabled="!batch_mode"
+                  :class="{'red-button': in_batch_mode, 'gray-button': !in_batch_mode}"
+                  :disabled="!in_batch_mode"
                   @click.stop="request_batch_delete()"
           >
             Batch Delete
@@ -191,7 +191,7 @@ export default class InstructorFiles extends OpenFilesMixin implements Instructo
 
 
   // Returns whether we are in batch deletion mode
-  get batch_mode() {
+  get in_batch_mode() {
     return this.d_batch_to_be_deleted.length > 0;
   }
 

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -36,7 +36,7 @@
             :file="instructor_file"
             @click="view_file(instructor_file)"
             v-bind:selected="d_batch_to_be_deleted.some((f) => f.pk === instructor_file.pk)"
-            v-on:update:selected="toggle_file_for_batch_operation(instructor_file)"
+            v-on:update:selected="toggle_file_for_batch_operation(instructor_file, $event)"
             @delete_requested="request_single_delete(instructor_file)"
             class="sidebar-item"
             :class="{ active: current_filename === instructor_file.name }"
@@ -147,14 +147,12 @@ export default class InstructorFiles extends OpenFilesMixin implements Instructo
   // Array of files selected for deletion in batch mode
   d_batch_to_be_deleted = new Array<InstructorFile>();
 
-
-  toggle_file_for_batch_operation(file: InstructorFile) {
-    if (this.d_batch_to_be_deleted.some((f) => f.pk === file.pk)) {
-      this.d_batch_to_be_deleted = this.d_batch_to_be_deleted.filter((f) => f.pk !== file.pk);
-    }
-    else {
+  // Toggle a file to be included or excluded for a batch operation
+  toggle_file_for_batch_operation(file: InstructorFile, value: Boolean) {
+    if (value) 
       this.d_batch_to_be_deleted.push(file);
-    }
+    else 
+      this.d_batch_to_be_deleted = this.d_batch_to_be_deleted.filter((f) => f.pk !== file.pk);
   }
 
   // Called when a user presses the delete button inside of child SingleInstructorFile component

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -18,7 +18,9 @@
             <i class="fas fa-bars"></i>
           </span>
           <span class="sidebar-header-text"
-                v-if="!d_collapsed || current_filename === null">Uploaded Files</span>
+                v-if="!d_collapsed || current_filename === null">
+                  Uploaded Files
+          </span>
         </div>
 
         <div class="sidebar-content" v-if="!d_collapsed">
@@ -26,6 +28,7 @@
                                   :key="instructor_file.pk"
                                   :file="instructor_file"
                                   @click="view_file(instructor_file)"
+                                  @selected="toggleFileForBatchOperation(instructor_file.pk)"
                                   class="sidebar-item"
                                   :class="{'active': current_filename === instructor_file.name}">
           </single-instructor-file>
@@ -75,6 +78,19 @@ export default class InstructorFiles extends OpenFilesMixin implements Instructo
   d_collapsed = false;
   d_uploading = false;
   d_upload_progress: number | null = null;
+
+  d_files_list = new Set();
+
+  toggleFileForBatchOperation(key: string) {
+    if( this.d_files_list.has(key) ){
+      this.d_files_list.delete(key)
+      console.log(`deleted ${key}`)
+    }
+    else{
+      this.d_files_list.add(key)
+      console.log(`added ${key}`)
+    }
+  }
 
   // Do NOT modify the contents of this array!!
   get instructor_files(): ReadonlyArray<Readonly<InstructorFile>> {

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -14,13 +14,21 @@
     <div class="sidebar-container">
       <div class="sidebar-menu">
         <div :class="['sidebar-header', {'sidebar-header-closed': d_collapsed}]">
-          <span class="sidebar-collapse-button" @click="d_collapsed = !d_collapsed">
-            <i class="fas fa-bars"></i>
-          </span>
-          <span class="sidebar-header-text"
-                v-if="!d_collapsed || current_filename === null">
-                  Uploaded Files
-          </span>
+          <div>
+            <span class="sidebar-collapse-button" @click="d_collapsed = !d_collapsed">
+              <i class="fas fa-bars"></i>
+            </span>
+            <span class="sidebar-header-text"
+                  v-if="!d_collapsed || current_filename === null">
+                    Uploaded Files
+            </span>
+          </div>
+          <div>
+            <button v-if="d_batch_mode" class="batch-delete-files-button red-button">
+              Delete
+            </button>
+            <input class="batch-select-all-checkbox" type="checkbox" @click="batch_toggle_all()" />
+          </div>
         </div>
 
         <div class="sidebar-content" v-if="!d_collapsed">
@@ -79,9 +87,10 @@ export default class InstructorFiles extends OpenFilesMixin implements Instructo
   d_uploading = false;
   d_upload_progress: number | null = null;
 
-  d_files_list = new Set();
+  d_files_list = new Set<Number>();
+  d_batch_mode = false;
 
-  toggleFileForBatchOperation(key: string) {
+  toggleFileForBatchOperation(key: Number) {
     if( this.d_files_list.has(key) ){
       this.d_files_list.delete(key)
       console.log(`deleted ${key}`)
@@ -90,7 +99,10 @@ export default class InstructorFiles extends OpenFilesMixin implements Instructo
       this.d_files_list.add(key)
       console.log(`added ${key}`)
     }
+
+    this.d_batch_mode = this.d_files_list.size > 0;
   }
+
 
   // Do NOT modify the contents of this array!!
   get instructor_files(): ReadonlyArray<Readonly<InstructorFile>> {
@@ -202,10 +214,16 @@ $border-color: hsl(220, 40%, 94%);
 }
 
 .sidebar-header {
+  display: flex;
+  justify-content: space-between;
   padding-top: .5rem;
   padding-bottom: .5rem;
   font-weight: bold;
   font-size: 1.125rem;
+}
+
+.sidebar-header-text {
+  white-space: nowrap;
 }
 
 .sidebar-collapse-button {
@@ -215,6 +233,15 @@ $border-color: hsl(220, 40%, 94%);
   &:hover {
     color: darken($ocean-blue, 10);
   }
+}
+
+.batch-delete-files-button {
+  white-space: nowrap;
+  font-size: 0.875rem;
+}
+
+.batch-select-all-checkbox {
+  margin: 0 0.5em;
 }
 
 .sidebar-item {

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -35,8 +35,8 @@
             :key="instructor_file.pk"
             :file="instructor_file"
             @click="view_file(instructor_file)"
-            v-bind:selected="d_batch_to_be_deleted.some((f) => f.pk === instructor_file.pk)"
-            v-on:selected="toggle_file_for_batch_operation(instructor_file, $event)"
+            :selected_for_deletion="d_batch_to_be_deleted.some((f) => f.pk === instructor_file.pk)"
+            @selected_for_deletion="toggle_file_for_batch_operation(instructor_file, $event)"
             @delete_requested="request_single_delete(instructor_file)"
             class="sidebar-item"
             :class="{ active: current_filename === instructor_file.name }"
@@ -177,10 +177,10 @@ export default class InstructorFiles extends OpenFilesMixin implements Instructo
       await Promise.all(
         this.d_to_be_deleted.map(async (file) => {
           await file.delete();
+          this.d_batch_to_be_deleted = this.d_batch_to_be_deleted.filter(f => f.pk !== file.pk);
         })
       );
 
-      this.d_batch_to_be_deleted = [];
       this.d_show_delete_modal = false;
     }
     finally {

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -98,6 +98,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
+
 import { InstructorFile, InstructorFileObserver, Project } from 'ag-client-typescript';
 
 import APIErrors from "@/components/api_errors.vue";
@@ -148,11 +149,13 @@ export default class InstructorFiles extends OpenFilesMixin implements Instructo
   d_batch_to_be_deleted = new Array<InstructorFile>();
 
   // Toggle a file to be included or excluded for a batch operation
-  toggle_file_for_batch_operation(file: InstructorFile, value: Boolean) {
-    if (value) 
+  toggle_file_for_batch_operation(file: InstructorFile, value: boolean) {
+    if (value) {
       this.d_batch_to_be_deleted.push(file);
-    else 
+    }
+    else {
       this.d_batch_to_be_deleted = this.d_batch_to_be_deleted.filter((f) => f.pk !== file.pk);
+    }
   }
 
   // Called when a user presses the delete button inside of child SingleInstructorFile component

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -273,7 +273,6 @@ function handle_file_upload_errors(component: InstructorFiles, error: unknown) {
 @import "@/styles/colors.scss";
 @import "@/styles/button_styles.scss";
 @import "@/styles/collapsible_sidebar.scss";
-@import "@/styles/forms.scss";
 @import "@/styles/modal.scss";
 
 * {
@@ -308,10 +307,6 @@ $border-color: hsl(220, 40%, 94%);
   white-space: nowrap;
 }
 
-.batch-select-all-checkbox {
-  margin: 0 .5em;
-}
-
 .sidebar-container {
   margin-top: .875rem;
 
@@ -321,10 +316,6 @@ $border-color: hsl(220, 40%, 94%);
 
   .sidebar-menu {
     .sidebar-header {
-      display: flex;
-      justify-content: space-between;
-      padding-top: .5rem;
-      padding-bottom: .5rem;
       font-weight: bold;
       font-size: 1.125rem;
 

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -1,10 +1,8 @@
 <template>
   <div id="instructor-files-component">
-    <file-upload
-      ref="instructor_files_upload"
-      @upload_files="add_instructor_files($event)"
-      :disable_upload_button="d_uploading"
-    >
+    <file-upload ref="instructor_files_upload"
+                 @upload_files="add_instructor_files($event)"
+                 :disable_upload_button="d_uploading">
     </file-upload>
 
     <div v-if="d_upload_progress !== null" class="progress-wrapper">
@@ -15,28 +13,18 @@
 
     <div class="sidebar-container">
       <div class="sidebar-menu">
-        <div
-          :class="['sidebar-header', { 'sidebar-header-closed': d_collapsed }]"
-        >
-          <div>
-            <span
-              class="sidebar-collapse-button"
-              @click="d_collapsed = !d_collapsed"
-            >
-              <i class="fas fa-bars"></i>
-            </span>
-            <span
-              class="sidebar-header-text"
-              v-if="!d_collapsed || current_filename === null"
-            >
-              Uploaded Files
-            </span>
+        <div :class="['sidebar-header', { 'sidebar-header-closed': d_collapsed }]">
+        <div :class="['sidebar-header', {'sidebar-header-closed': d_collapsed}]">
+          <span class="sidebar-collapse-button" @click="d_collapsed = !d_collapsed">
+            <i class="fas fa-bars"></i>
+          </span>
+          <span class="sidebar-header-text"
+                v-if="!d_collapsed || current_filename === null">Uploaded Files</span>
           </div>
           <div>
-            <button
-              v-if="d_batch_mode"
-              class="batch-delete-files-button red-button"
-              @click.stop="request_batch_delete()"
+            <button v-if="d_batch_mode"
+                    class="batch-delete-files-button red-button"
+                    @click.stop="request_batch_delete()"
             >
               Delete
             </button>
@@ -57,15 +45,10 @@
           </single-instructor-file>
         </div>
       </div>
-      <div
-        :class="['body', { 'body-closed': d_collapsed }]"
-        v-if="current_filename !== null"
-      >
-        <view-file
-          :filename="current_filename"
-          :file_contents="current_file_contents"
-          :progress="load_contents_progress"
-        ></view-file>
+      <div :class="['body', {'body-closed': d_collapsed}]" v-if="current_filename !== null">
+        <view-file :filename="current_filename"
+                   :file_contents="current_file_contents"
+                   :progress="load_contents_progress"></view-file>
       </div>
     </div>
     <div @click.stop>
@@ -115,30 +98,25 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from "vue-property-decorator";
-
-import {
-  InstructorFile,
-  InstructorFileObserver,
-  Project,
-} from "ag-client-typescript";
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { InstructorFile, InstructorFileObserver, Project } from 'ag-client-typescript';
 
 import APIErrors from "@/components/api_errors.vue";
-import FileUpload from "@/components/file_upload.vue";
-import Modal from "@/components/modal.vue";
-import ProgressBar from "@/components/progress_bar.vue";
-import ViewFile from "@/components/view_file.vue";
+import FileUpload from '@/components/file_upload.vue';
+import Modal from '@/components/modal.vue';
+import ProgressBar from '@/components/progress_bar.vue';
+import ViewFile from '@/components/view_file.vue';
 import {
   handle_api_errors_async,
   handle_global_errors_async,
   make_error_handler_func,
 } from "@/error_handling";
-import { BeforeDestroy, Created } from "@/lifecycle";
-import { OpenFilesMixin } from "@/open_files_mixin";
-import { SafeMap } from "@/safe_map";
-import { toggle } from "@/utils";
+import { BeforeDestroy, Created } from '@/lifecycle';
+import { OpenFilesMixin } from '@/open_files_mixin';
+import { SafeMap } from '@/safe_map';
+import { toggle } from '@/utils';
 
-import SingleInstructorFile from "./single_instructor_file.vue";
+import SingleInstructorFile from './single_instructor_file.vue';
 
 @Component({
   components: {
@@ -150,10 +128,10 @@ import SingleInstructorFile from "./single_instructor_file.vue";
     ViewFile,
   },
 })
-export default class InstructorFiles
-  extends OpenFilesMixin
-  implements InstructorFileObserver, Created, BeforeDestroy {
-  @Prop({ required: true, type: Project })
+export default class InstructorFiles extends OpenFilesMixin implements InstructorFileObserver,
+                                                                       Created,
+                                                                       BeforeDestroy {
+  @Prop({required: true, type: Project})
   project!: Project;
 
   d_collapsed = false;
@@ -240,37 +218,28 @@ export default class InstructorFiles
   }
 
   view_file(file: InstructorFile) {
-    this.open_file(file.name, (progress_callback) =>
-      file.get_content(progress_callback)
-    );
+    this.open_file(file.name, (progress_callback) => file.get_content(progress_callback));
   }
 
   @handle_api_errors_async(handle_file_upload_errors)
   add_instructor_files(files: File[]) {
     this.d_upload_progress = null;
     (<APIErrors> this.$refs.api_errors).clear();
-    return toggle(this, "d_uploading", async () => {
+    return toggle(this, 'd_uploading', async () => {
       for (let file of files) {
-        let file_to_update = this.instructor_files.find(
-          (item) => item.name === file.name
-        );
+        let file_to_update = this.instructor_files.find(item => item.name === file.name);
         if (file_to_update !== undefined) {
           await file_to_update.set_content(file, (event: ProgressEvent) => {
             if (event.lengthComputable) {
-              this.d_upload_progress =
-                100 * ((1.0 * event.loaded) / event.total);
+              this.d_upload_progress = 100 * (1.0 * event.loaded / event.total);
             }
           });
         }
         else {
           await InstructorFile.create(
-            this.project.pk,
-            file.name,
-            file,
-            (event: ProgressEvent) => {
+            this.project.pk, file.name, file, (event: ProgressEvent) => {
               if (event.lengthComputable) {
-                this.d_upload_progress =
-                  100 * ((1.0 * event.loaded) / event.total);
+                this.d_upload_progress = 100 * (1.0 * event.loaded / event.total);
               }
             }
           );
@@ -281,10 +250,7 @@ export default class InstructorFiles
     });
   }
 
-  update_instructor_file_content_changed(
-    instructor_file: InstructorFile,
-    file_content: Blob
-  ) {
+  update_instructor_file_content_changed(instructor_file: InstructorFile, file_content: Blob) {
     if (instructor_file.project === this.project.pk) {
       this.update_file(instructor_file.name, Promise.resolve(file_content));
     }
@@ -296,10 +262,7 @@ export default class InstructorFiles
     }
   }
 
-  update_instructor_file_renamed(
-    instructor_file: InstructorFile,
-    old_name: string
-  ) {
+  update_instructor_file_renamed(instructor_file: InstructorFile, old_name: string) {
     if (instructor_file.project === this.project.pk) {
       this.rename_file(old_name, instructor_file.name);
     }
@@ -327,11 +290,11 @@ function handle_file_upload_errors(component: InstructorFiles, error: unknown) {
 }
 
 #instructor-files-component {
-  margin-top: 0.625rem;
+  margin-top: .625rem;
 }
 
 .progress-wrapper {
-  padding-top: 0.625rem;
+  padding-top: .625rem;
 }
 
 $border-color: hsl(220, 40%, 94%);
@@ -346,14 +309,14 @@ $border-color: hsl(220, 40%, 94%);
 );
 
 .sidebar-container {
-  margin-top: 0.875rem;
+  margin-top: .875rem;
 }
 
 .sidebar-header {
   display: flex;
   justify-content: space-between;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-top: .5rem;
+  padding-bottom: .5rem;
   font-weight: bold;
   font-size: 1.125rem;
 }
@@ -373,11 +336,11 @@ $border-color: hsl(220, 40%, 94%);
 
 .batch-delete-files-button {
   white-space: nowrap;
-  font-size: 0.875rem;
+  font-size: .875rem;
 }
 
 .batch-select-all-checkbox {
-  margin: 0 0.5em;
+  margin: 0 .5em;
 }
 
 .sidebar-item {

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -13,22 +13,20 @@
 
     <div class="sidebar-container">
       <div class="sidebar-menu">
-        <div :class="['sidebar-header', { 'sidebar-header-closed': d_collapsed }]">
         <div :class="['sidebar-header', {'sidebar-header-closed': d_collapsed}]">
-          <span class="sidebar-collapse-button" @click="d_collapsed = !d_collapsed">
-            <i class="fas fa-bars"></i>
-          </span>
-          <span class="sidebar-header-text"
-                v-if="!d_collapsed || current_filename === null">Uploaded Files</span>
-          </div>
           <div>
-            <button v-if="!d_collapsed && batch_mode"
-                    class="batch-delete-files-button red-button"
-                    @click.stop="request_batch_delete()"
-            >
-              Delete
-            </button>
+            <span class="sidebar-collapse-button" @click="d_collapsed = !d_collapsed">
+              <i class="fas fa-bars"></i>
+            </span>
+            <span class="sidebar-header-text"
+                  v-if="!d_collapsed || current_filename === null">Uploaded Files</span>
           </div>
+          <button v-if="!d_collapsed && batch_mode"
+                  class="batch-delete-files-button red-button"
+                  @click.stop="request_batch_delete()"
+          >
+            Delete
+          </button>
         </div>
 
         <div class="sidebar-content" v-if="!d_collapsed">
@@ -305,31 +303,6 @@ $border-color: hsl(220, 40%, 94%);
   $active-color: $pebble-light
 );
 
-.sidebar-container {
-  margin-top: .875rem;
-}
-
-.sidebar-header {
-  display: flex;
-  justify-content: space-between;
-  padding-top: .5rem;
-  padding-bottom: .5rem;
-  font-weight: bold;
-  font-size: 1.125rem;
-}
-
-.sidebar-header-text {
-  white-space: nowrap;
-}
-
-.sidebar-collapse-button {
-  color: $ocean-blue;
-  outline: none;
-
-  &:hover {
-    color: darken($ocean-blue, 10);
-  }
-}
 
 .batch-delete-files-button {
   white-space: nowrap;
@@ -340,15 +313,44 @@ $border-color: hsl(220, 40%, 94%);
   margin: 0 .5em;
 }
 
-.sidebar-item {
-  border-top: 1px solid $border-color;
-}
-
 .sidebar-container {
+  margin-top: .875rem;
+
   .body {
     border-top: 1px solid hsl(220, 40%, 94%);
   }
+
+  .sidebar-menu {
+    .sidebar-header {
+      display: flex;
+      justify-content: space-between;
+      padding-top: .5rem;
+      padding-bottom: .5rem;
+      font-weight: bold;
+      font-size: 1.125rem;
+
+      .sidebar-header-text {
+        white-space: nowrap;
+      }
+    }
+  }
+
+  .sidebar-content {
+    .sidebar-item {
+      border-top: 1px solid $border-color;
+    }
+
+    .sidebar-collapse-button {
+      color: $ocean-blue;
+      outline: none;
+
+      &:hover {
+        color: darken($ocean-blue, 10);
+      }
+    }
+  }
 }
+
 
 /* ---------------- MODAL ---------------- */
 

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -36,7 +36,7 @@
             :file="instructor_file"
             @click="view_file(instructor_file)"
             v-bind:selected="d_batch_to_be_deleted.some((f) => f.pk === instructor_file.pk)"
-            v-on:update:selected="toggle_file_for_batch_operation(instructor_file, $event)"
+            v-on:selected="toggle_file_for_batch_operation(instructor_file, $event)"
             @delete_requested="request_single_delete(instructor_file)"
             class="sidebar-item"
             :class="{ active: current_filename === instructor_file.name }"

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -14,13 +14,11 @@
     <div class="sidebar-container">
       <div class="sidebar-menu">
         <div :class="['sidebar-header', {'sidebar-header-closed': d_collapsed}]">
-          <div>
-            <span class="sidebar-collapse-button" @click="d_collapsed = !d_collapsed">
-              <i class="fas fa-bars"></i>
-            </span>
-            <span class="sidebar-header-text"
-                  v-if="!d_collapsed || current_filename === null">Uploaded Files</span>
-          </div>
+          <span class="sidebar-collapse-button" @click="d_collapsed = !d_collapsed">
+            <i class="fas fa-bars"></i>
+          </span>
+          <span class="sidebar-header-text"
+                v-if="!d_collapsed || current_filename === null">Uploaded Files</span>
           <button v-if="!d_collapsed"
                   class="batch-delete-files-button"
                   :class="{'red-button': batch_mode, 'gray-button': !batch_mode}"
@@ -305,8 +303,9 @@ $border-color: hsl(220, 40%, 94%);
 
 
 .batch-delete-files-button {
-  white-space: nowrap;
   font-size: .875rem;
+  margin-left: auto;
+  white-space: nowrap;
 }
 
 .batch-select-all-checkbox {

--- a/src/components/project_admin/instructor_files/instructor_files.vue
+++ b/src/components/project_admin/instructor_files/instructor_files.vue
@@ -273,6 +273,7 @@ function handle_file_upload_errors(component: InstructorFiles, error: unknown) {
 @import "@/styles/colors.scss";
 @import "@/styles/button_styles.scss";
 @import "@/styles/collapsible_sidebar.scss";
+@import "@/styles/forms.scss";
 @import "@/styles/modal.scss";
 
 * {

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -34,41 +34,12 @@
       <i class="fas fa-file-download download-file"
          @click.stop="download_file"></i>
       <i class="far fa-trash-alt delete-file"
-         @click.stop="d_show_delete_instructor_file_modal = true"></i>
+         @click.stop="$emit('delete_requested')"></i>
       <input @click="$emit('selected')" type="checkbox" />
     </div>
     <div class="display-timestamp">
       {{format_datetime(file.last_modified)}}
     </div>
-    <div @click.stop>
-      <modal v-if="d_show_delete_instructor_file_modal"
-             @close="d_show_delete_instructor_file_modal = false"
-             ref="delete_instructor_file_modal"
-             size="large"
-             click_outside_to_close>
-        <div class="modal-header">Confirm Delete</div>
-        <div> Are you sure you want to delete
-          <span class="file-to-delete">{{file.name}}</span>? <br><br>
-
-          If you want to <b>update the file's contents</b>, cancel this dialogue
-          and <b>re-upload the file instead.</b> <br><br>
-
-          <b>This action cannot be undone</b>. <br>
-          Any test cases that rely on this file may have
-          to be updated before they'll run correctly again.
-        </div>
-
-        <APIErrors ref="delete_errors"></APIErrors>
-        <div class="button-footer-right modal-button-footer">
-          <button class="modal-delete-button"
-                  :disabled="d_delete_pending"
-                  @click="delete_file_permanently"> Delete </button>
-          <button class="modal-cancel-button"
-                  @click="d_show_delete_instructor_file_modal = false"> Cancel </button>
-        </div>
-      </modal>
-    </div>
-
     <progress-overlay v-if="d_downloading" :progress="d_download_progress"></progress-overlay>
   </div>
 </template>
@@ -109,11 +80,9 @@ export default class SingleInstructorFile extends Vue {
   readonly is_not_empty = is_not_empty;
   readonly format_datetime = format_datetime;
 
-  d_delete_pending = false;
   editing = false;
   new_file_name: string = "";
   new_name_is_valid = true;
-  d_show_delete_instructor_file_modal = false;
 
   d_download_progress: number | null = null;
   d_downloading = false;
@@ -142,18 +111,6 @@ export default class SingleInstructorFile extends Vue {
       FileSaver.saveAs(new File([await file_content], this.file.name));
       this.d_download_progress = null;
     });
-  }
-
-  @handle_api_errors_async(make_error_handler_func('delete_errors'))
-  async delete_file_permanently() {
-    try {
-      this.d_delete_pending = true;
-      await this.file.delete();
-      this.d_show_delete_instructor_file_modal = false;
-    }
-    finally {
-      this.d_delete_pending = false;
-    }
   }
 }
 
@@ -247,18 +204,4 @@ export function handle_rename_file_error(component: SingleInstructorFile, error:
   font-size: .875rem;
 }
 
-/* ---------------- MODAL ---------------- */
-
-.file-to-delete {
-  color: darken($ocean-blue, 5%);
-  font-weight: bold;
-}
-
-.modal-cancel-button {
-  @extend .white-button;
-}
-
-.modal-delete-button {
-  @extend .red-button;
-}
 </style>

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -35,7 +35,7 @@
          @click.stop="download_file"></i>
       <i class="far fa-trash-alt delete-file"
          @click.stop="$emit('delete_requested')"></i>
-      <input @click="$emit('selected')" type="checkbox" />
+      <input @click.stop @change.stop="$emit('selected')" type="checkbox" />
     </div>
     <div class="display-timestamp">
       {{format_datetime(file.last_modified)}}

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -63,7 +63,7 @@ import {
   handle_api_errors_async,
   handle_global_errors_async,
   make_error_handler_func,
-} from "@/error_handling";
+} from '@/error_handling';
 import { format_datetime, toggle } from '@/utils';
 import { is_not_empty } from '@/validators';
 
@@ -219,8 +219,7 @@ export function handle_rename_file_error(component: SingleInstructorFile, error:
   margin-left: .625rem;
 }
 
-.update-file-name-button,
-.update-file-name-cancel-button {
+.update-file-name-button, .update-file-name-cancel-button {
   padding: .25rem .375rem;
 }
 

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -37,7 +37,7 @@
       <i class="far fa-trash-alt delete-file"
          @click.stop="$emit('delete_requested')"
       ></i>
-      <input @click.stop @change.stop="$emit('selected')" type="checkbox" />
+      <input @click.stop v-model="selectedProxy" type="checkbox" />
     </div>
     <div class="display-timestamp">
       {{format_datetime(file.last_modified)}}
@@ -78,6 +78,9 @@ export default class SingleInstructorFile extends Vue {
   @Prop({required: true, type: InstructorFile})
   file!: InstructorFile;
 
+  @Prop({required: false, type: Boolean})
+  selected!: Boolean;
+
   readonly is_not_empty = is_not_empty;
   readonly format_datetime = format_datetime;
 
@@ -87,6 +90,14 @@ export default class SingleInstructorFile extends Vue {
 
   d_download_progress: number | null = null;
   d_downloading = false;
+
+  get selectedProxy() : Boolean {
+    return this.selected;
+  }
+
+  set selectedProxy(value: Boolean) {
+    this.$emit('update:selected', value);
+  }
 
   @handle_api_errors_async(handle_rename_file_error)
   async rename_file() {

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -35,6 +35,7 @@
          @click.stop="download_file"></i>
       <i class="far fa-trash-alt delete-file"
          @click.stop="d_show_delete_instructor_file_modal = true"></i>
+      <input @click="$emit('selected')" type="checkbox" />
     </div>
     <div class="display-timestamp">
       {{format_datetime(file.last_modified)}}

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -85,7 +85,7 @@ export default class SingleInstructorFile extends Vue {
   file!: InstructorFile;
 
   @Prop({required: false, type: Boolean})
-  selected_for_deletion!: Boolean;
+  selected_for_deletion!: boolean;
 
   readonly is_not_empty = is_not_empty;
   readonly format_datetime = format_datetime;

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -29,7 +29,11 @@
       <APIErrors ref="api_errors"></APIErrors>
     </div>
     <div v-else class="not-editing">
-      <input class="select-checkbox" @click.stop v-model="selectedProxy" type="checkbox" />
+      <input class="select-checkbox" 
+             @click.stop 
+             :checked="selected_for_deletion" 
+             @change="$emit('selected_for_deletion', $event.target.checked)"
+             type="checkbox" />
       <div class="file-info-actions">
         <div class="file-name">{{file.name}}</div>
         <i class="fas fa-pencil-alt edit-file-name"
@@ -81,7 +85,7 @@ export default class SingleInstructorFile extends Vue {
   file!: InstructorFile;
 
   @Prop({required: false, type: Boolean})
-  selected!: Boolean;
+  selected_for_deletion!: Boolean;
 
   readonly is_not_empty = is_not_empty;
   readonly format_datetime = format_datetime;
@@ -92,14 +96,6 @@ export default class SingleInstructorFile extends Vue {
 
   d_download_progress: number | null = null;
   d_downloading = false;
-
-  get selectedProxy() : Boolean {
-    return this.selected;
-  }
-
-  set selectedProxy(value: Boolean) {
-    this.$emit('selected', value);
-  }
 
   @handle_api_errors_async(handle_rename_file_error)
   async rename_file() {

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -1,35 +1,27 @@
 <template>
   <div class="single-instructor-file-component" v-on="$listeners">
     <div v-if="editing">
-      <validated-form
-        autocomplete="off"
-        spellcheck="false"
-        ref="rename_form"
-        @submit="rename_file"
-      >
-        <validated-input
-          ref="file_name"
-          v-model="new_file_name"
-          :validators="[is_not_empty]"
-          input_style="width: 200px;
+      <validated-form autocomplete="off"
+                      spellcheck="false"
+                      ref="rename_form"
+                      @submit="rename_file">
+        <validated-input ref="file_name"
+                         v-model="new_file_name"
+                         :validators="[is_not_empty]"
+                         input_style="width: 200px;
                                      padding: 3px 5px;
                                      margin-right: 10px;"
-          @input_validity_changed="new_name_is_valid = $event"
-        >
+                         @input_validity_changed="new_name_is_valid = $event">
         </validated-input>
         <div class="edit-name-buttons">
-          <button
-            class="update-file-name-button"
-            type="submit"
-            :disabled="!new_name_is_valid"
-            @click.stop
-          >
+          <button class="update-file-name-button"
+                  type="submit"
+                  :disabled="!new_name_is_valid"
+                  @click.stop>
             Save
           </button>
-          <button
-            class="update-file-name-cancel-button"
-            @click.stop="cancel_renaming_file"
-          >
+          <button class="update-file-name-cancel-button"
+                  @click.stop="cancel_renaming_file">
             Cancel
           </button>
         </div>
@@ -37,52 +29,41 @@
       <APIErrors ref="api_errors"></APIErrors>
     </div>
     <div v-else class="not-editing">
-      <div class="file-name">{{ file.name }}</div>
-      <i
-        class="fas fa-pencil-alt edit-file-name"
-        @click.stop="
-          new_file_name = file.name;
-          editing = true;
-        "
-      ></i>
-      <i
-        class="fas fa-file-download download-file"
-        @click.stop="download_file"
-      ></i>
-      <i
-        class="far fa-trash-alt delete-file"
-        @click.stop="$emit('delete_requested')"
+      <div class="file-name">{{file.name}}</div>
+      <i class="fas fa-pencil-alt edit-file-name"
+         @click.stop="new_file_name = file.name; editing = true;"></i>
+      <i class="fas fa-file-download download-file"
+         @click.stop="download_file"></i>
+      <i class="far fa-trash-alt delete-file"
+         @click.stop="$emit('delete_requested')"
       ></i>
       <input @click.stop @change.stop="$emit('selected')" type="checkbox" />
     </div>
     <div class="display-timestamp">
-      {{ format_datetime(file.last_modified) }}
+      {{format_datetime(file.last_modified)}}
     </div>
-    <progress-overlay
-      v-if="d_downloading"
-      :progress="d_download_progress"
-    ></progress-overlay>
+    <progress-overlay v-if="d_downloading" :progress="d_download_progress"></progress-overlay>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from "vue-property-decorator";
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
-import { InstructorFile } from "ag-client-typescript";
-import * as FileSaver from "file-saver";
+import { InstructorFile } from 'ag-client-typescript';
+import * as FileSaver from 'file-saver';
 
-import APIErrors from "@/components/api_errors.vue";
-import Modal from "@/components/modal.vue";
-import ProgressOverlay from "@/components/progress_overlay.vue";
-import ValidatedForm from "@/components/validated_form.vue";
-import ValidatedInput from "@/components/validated_input.vue";
+import APIErrors from '@/components/api_errors.vue';
+import Modal from '@/components/modal.vue';
+import ProgressOverlay from '@/components/progress_overlay.vue';
+import ValidatedForm from '@/components/validated_form.vue';
+import ValidatedInput from '@/components/validated_input.vue';
 import {
   handle_api_errors_async,
   handle_global_errors_async,
   make_error_handler_func,
 } from "@/error_handling";
-import { format_datetime, toggle } from "@/utils";
-import { is_not_empty } from "@/validators";
+import { format_datetime, toggle } from '@/utils';
+import { is_not_empty } from '@/validators';
 
 @Component({
   components: {
@@ -90,11 +71,11 @@ import { is_not_empty } from "@/validators";
     Modal,
     ProgressOverlay,
     ValidatedForm,
-    ValidatedInput,
-  },
+    ValidatedInput
+  }
 })
 export default class SingleInstructorFile extends Vue {
-  @Prop({ required: true, type: InstructorFile })
+  @Prop({required: true, type: InstructorFile})
   file!: InstructorFile;
 
   readonly is_not_empty = is_not_empty;
@@ -122,10 +103,10 @@ export default class SingleInstructorFile extends Vue {
   @handle_global_errors_async
   download_file() {
     this.d_download_progress = null;
-    return toggle(this, "d_downloading", async () => {
+    return toggle(this, 'd_downloading', async () => {
       let file_content = this.file.get_content((event: ProgressEvent) => {
         if (event.lengthComputable) {
-          this.d_download_progress = 100 * ((1.0 * event.loaded) / event.total);
+          this.d_download_progress = 100 * (1.0 * event.loaded / event.total);
         }
       });
       FileSaver.saveAs(new File([await file_content], this.file.name));
@@ -134,19 +115,16 @@ export default class SingleInstructorFile extends Vue {
   }
 }
 
-export function handle_rename_file_error(
-  component: SingleInstructorFile,
-  error: unknown
-) {
+export function handle_rename_file_error(component: SingleInstructorFile, error: unknown) {
   (<APIErrors> component.$refs.api_errors).show_errors_from_response(error);
 }
 </script>
 
 <style scoped lang="scss">
-@import "@/styles/button_styles.scss";
-@import "@/styles/colors.scss";
-@import "@/styles/forms.scss";
-@import "@/styles/modal.scss";
+@import '@/styles/button_styles.scss';
+@import '@/styles/colors.scss';
+@import '@/styles/forms.scss';
+@import '@/styles/modal.scss';
 
 * {
   box-sizing: border-box;
@@ -155,13 +133,13 @@ export function handle_rename_file_error(
 .single-instructor-file-component {
   cursor: pointer;
 
-  padding: 0.5rem 0.75rem;
+  padding: .5rem .75rem;
   word-wrap: break-word;
   word-break: break-word;
 }
 
 .icon-holder {
-  padding-top: 0.125rem;
+  padding-top: .125rem;
 }
 
 .not-editing {
@@ -169,13 +147,11 @@ export function handle_rename_file_error(
 
   .file-name {
     font-size: 16px;
-    padding-bottom: 0.125rem;
+    padding-bottom: .125rem;
   }
 
-  .edit-file-name,
-  .download-file,
-  .delete-file {
-    margin: 0 0.375rem;
+  .edit-file-name, .download-file, .delete-file {
+    margin: 0 .375rem;
   }
 
   .edit-file-name {
@@ -206,7 +182,7 @@ export function handle_rename_file_error(
 
 .edit-name-buttons {
   display: flex;
-  padding: 0.5rem 0;
+  padding: .5rem 0;
 }
 
 .update-file-name-button {
@@ -215,17 +191,17 @@ export function handle_rename_file_error(
 
 .update-file-name-cancel-button {
   @extend .flat-white-button;
-  margin-left: 0.625rem;
+  margin-left: .625rem;
 }
 
 .update-file-name-button,
 .update-file-name-cancel-button {
-  padding: 0.25rem 0.375rem;
+  padding: .25rem .375rem;
 }
 
 .display-timestamp {
   display: block;
   color: hsl(220, 20%, 65%);
-  font-size: 0.875rem;
+  font-size: .875rem;
 }
 </style>

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -29,15 +29,17 @@
       <APIErrors ref="api_errors"></APIErrors>
     </div>
     <div v-else class="not-editing">
-      <div class="file-name">{{file.name}}</div>
-      <i class="fas fa-pencil-alt edit-file-name"
-         @click.stop="new_file_name = file.name; editing = true;"></i>
-      <i class="fas fa-file-download download-file"
-         @click.stop="download_file"></i>
-      <i class="far fa-trash-alt delete-file"
-         @click.stop="$emit('delete_requested')"
-      ></i>
-      <input @click.stop v-model="selectedProxy" type="checkbox" />
+      <input class="select-checkbox" @click.stop v-model="selectedProxy" type="checkbox" />
+      <div class="file-info-actions">
+        <div class="file-name">{{file.name}}</div>
+        <i class="fas fa-pencil-alt edit-file-name"
+          @click.stop="new_file_name = file.name; editing = true;"></i>
+        <i class="fas fa-file-download download-file"
+          @click.stop="download_file"></i>
+        <i class="far fa-trash-alt delete-file"
+          @click.stop="$emit('delete_requested')"
+        ></i>
+      </div>
     </div>
     <div class="display-timestamp">
       {{format_datetime(file.last_modified)}}
@@ -144,7 +146,7 @@ export function handle_rename_file_error(component: SingleInstructorFile, error:
 .single-instructor-file-component {
   cursor: pointer;
 
-  padding: .5rem .75rem;
+  padding: .5rem .10rem;
   word-wrap: break-word;
   word-break: break-word;
 }
@@ -156,38 +158,50 @@ export function handle_rename_file_error(component: SingleInstructorFile, error:
 .not-editing {
   display: flex;
 
-  .file-name {
-    font-size: 16px;
-    padding-bottom: .125rem;
+  .select-checkbox {
+    width: 1.35rem;
+    transform: scale(1.35);
   }
 
-  .edit-file-name, .download-file, .delete-file {
-    margin: 0 .375rem;
-  }
+  .file-info-actions {
+    display: flex;
+    justify-content: space-between;
+    width: 90%;
 
-  .edit-file-name {
-    color: hsl(220, 30%, 60%);
-    margin-left: auto;
-  }
+    .file-name {
+      font-size: 16px;
+      padding-bottom: .125rem;
+      margin-right: auto;
+    }
 
-  .edit-file-name:hover {
-    color: hsl(220, 30%, 35%);
-  }
+    .edit-file-name, .download-file, .delete-file {
+      margin: 0 .375rem;
+    }
 
-  .download-file {
-    color: hsl(220, 30%, 60%);
-  }
+    .edit-file-name {
+      color: hsl(220, 30%, 60%);
+      margin-left: auto;
+    }
 
-  .download-file:hover {
-    color: hsl(220, 30%, 35%);
-  }
+    .edit-file-name:hover {
+      color: hsl(220, 30%, 35%);
+    }
 
-  .delete-file {
-    color: hsl(220, 20%, 75%);
-  }
+    .download-file {
+      color: hsl(220, 30%, 60%);
+    }
 
-  .delete-file:hover {
-    color: hsl(220, 20%, 55%);
+    .download-file:hover {
+      color: hsl(220, 30%, 35%);
+    }
+
+    .delete-file {
+      color: hsl(220, 20%, 75%);
+    }
+
+    .delete-file:hover {
+      color: hsl(220, 20%, 55%);
+    }
   }
 }
 
@@ -214,5 +228,6 @@ export function handle_rename_file_error(component: SingleInstructorFile, error:
   display: block;
   color: hsl(220, 20%, 65%);
   font-size: .875rem;
+  margin-left: 1.75rem;
 }
 </style>

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -98,7 +98,7 @@ export default class SingleInstructorFile extends Vue {
   }
 
   set selectedProxy(value: Boolean) {
-    this.$emit('update:selected', value);
+    this.$emit('selected', value);
   }
 
   @handle_api_errors_async(handle_rename_file_error)

--- a/src/components/project_admin/instructor_files/single_instructor_file.vue
+++ b/src/components/project_admin/instructor_files/single_instructor_file.vue
@@ -1,67 +1,88 @@
 <template>
   <div class="single-instructor-file-component" v-on="$listeners">
     <div v-if="editing">
-      <validated-form autocomplete="off"
-                      spellcheck="false"
-                      ref="rename_form"
-                      @submit=rename_file>
-        <validated-input ref='file_name'
-                         v-model="new_file_name"
-                         :validators="[is_not_empty]"
-                         input_style="width: 200px;
+      <validated-form
+        autocomplete="off"
+        spellcheck="false"
+        ref="rename_form"
+        @submit="rename_file"
+      >
+        <validated-input
+          ref="file_name"
+          v-model="new_file_name"
+          :validators="[is_not_empty]"
+          input_style="width: 200px;
                                      padding: 3px 5px;
                                      margin-right: 10px;"
-                         @input_validity_changed="new_name_is_valid = $event">
+          @input_validity_changed="new_name_is_valid = $event"
+        >
         </validated-input>
         <div class="edit-name-buttons">
-          <button class="update-file-name-button"
-                  type="submit"
-                  :disabled="!new_name_is_valid"
-                  @click.stop>
+          <button
+            class="update-file-name-button"
+            type="submit"
+            :disabled="!new_name_is_valid"
+            @click.stop
+          >
             Save
           </button>
-          <button class="update-file-name-cancel-button"
-                  @click.stop="cancel_renaming_file"> Cancel
+          <button
+            class="update-file-name-cancel-button"
+            @click.stop="cancel_renaming_file"
+          >
+            Cancel
           </button>
         </div>
       </validated-form>
       <APIErrors ref="api_errors"></APIErrors>
     </div>
     <div v-else class="not-editing">
-      <div class="file-name">{{file.name}}</div>
-      <i class="fas fa-pencil-alt edit-file-name"
-         @click.stop="new_file_name = file.name; editing = true;"></i>
-      <i class="fas fa-file-download download-file"
-         @click.stop="download_file"></i>
-      <i class="far fa-trash-alt delete-file"
-         @click.stop="$emit('delete_requested')"></i>
+      <div class="file-name">{{ file.name }}</div>
+      <i
+        class="fas fa-pencil-alt edit-file-name"
+        @click.stop="
+          new_file_name = file.name;
+          editing = true;
+        "
+      ></i>
+      <i
+        class="fas fa-file-download download-file"
+        @click.stop="download_file"
+      ></i>
+      <i
+        class="far fa-trash-alt delete-file"
+        @click.stop="$emit('delete_requested')"
+      ></i>
       <input @click.stop @change.stop="$emit('selected')" type="checkbox" />
     </div>
     <div class="display-timestamp">
-      {{format_datetime(file.last_modified)}}
+      {{ format_datetime(file.last_modified) }}
     </div>
-    <progress-overlay v-if="d_downloading" :progress="d_download_progress"></progress-overlay>
+    <progress-overlay
+      v-if="d_downloading"
+      :progress="d_download_progress"
+    ></progress-overlay>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 
-import { InstructorFile } from 'ag-client-typescript';
-import * as FileSaver from 'file-saver';
+import { InstructorFile } from "ag-client-typescript";
+import * as FileSaver from "file-saver";
 
-import APIErrors from '@/components/api_errors.vue';
-import Modal from '@/components/modal.vue';
-import ProgressOverlay from '@/components/progress_overlay.vue';
-import ValidatedForm from '@/components/validated_form.vue';
-import ValidatedInput from '@/components/validated_input.vue';
+import APIErrors from "@/components/api_errors.vue";
+import Modal from "@/components/modal.vue";
+import ProgressOverlay from "@/components/progress_overlay.vue";
+import ValidatedForm from "@/components/validated_form.vue";
+import ValidatedInput from "@/components/validated_input.vue";
 import {
   handle_api_errors_async,
   handle_global_errors_async,
-  make_error_handler_func
-} from '@/error_handling';
-import { format_datetime, toggle } from '@/utils';
-import { is_not_empty } from '@/validators';
+  make_error_handler_func,
+} from "@/error_handling";
+import { format_datetime, toggle } from "@/utils";
+import { is_not_empty } from "@/validators";
 
 @Component({
   components: {
@@ -69,12 +90,11 @@ import { is_not_empty } from '@/validators';
     Modal,
     ProgressOverlay,
     ValidatedForm,
-    ValidatedInput
-  }
+    ValidatedInput,
+  },
 })
 export default class SingleInstructorFile extends Vue {
-
-  @Prop({required: true, type: InstructorFile})
+  @Prop({ required: true, type: InstructorFile })
   file!: InstructorFile;
 
   readonly is_not_empty = is_not_empty;
@@ -102,10 +122,10 @@ export default class SingleInstructorFile extends Vue {
   @handle_global_errors_async
   download_file() {
     this.d_download_progress = null;
-    return toggle(this, 'd_downloading', async () => {
+    return toggle(this, "d_downloading", async () => {
       let file_content = this.file.get_content((event: ProgressEvent) => {
         if (event.lengthComputable) {
-          this.d_download_progress = 100 * (1.0 * event.loaded / event.total);
+          this.d_download_progress = 100 * ((1.0 * event.loaded) / event.total);
         }
       });
       FileSaver.saveAs(new File([await file_content], this.file.name));
@@ -114,17 +134,19 @@ export default class SingleInstructorFile extends Vue {
   }
 }
 
-export function handle_rename_file_error(component: SingleInstructorFile, error: unknown) {
+export function handle_rename_file_error(
+  component: SingleInstructorFile,
+  error: unknown
+) {
   (<APIErrors> component.$refs.api_errors).show_errors_from_response(error);
 }
-
 </script>
 
 <style scoped lang="scss">
-@import '@/styles/button_styles.scss';
-@import '@/styles/colors.scss';
-@import '@/styles/forms.scss';
-@import '@/styles/modal.scss';
+@import "@/styles/button_styles.scss";
+@import "@/styles/colors.scss";
+@import "@/styles/forms.scss";
+@import "@/styles/modal.scss";
 
 * {
   box-sizing: border-box;
@@ -133,13 +155,13 @@ export function handle_rename_file_error(component: SingleInstructorFile, error:
 .single-instructor-file-component {
   cursor: pointer;
 
-  padding: .5rem .75rem;
+  padding: 0.5rem 0.75rem;
   word-wrap: break-word;
   word-break: break-word;
 }
 
 .icon-holder {
-  padding-top: .125rem;
+  padding-top: 0.125rem;
 }
 
 .not-editing {
@@ -147,11 +169,13 @@ export function handle_rename_file_error(component: SingleInstructorFile, error:
 
   .file-name {
     font-size: 16px;
-    padding-bottom: .125rem;
+    padding-bottom: 0.125rem;
   }
 
-  .edit-file-name, .download-file, .delete-file {
-    margin: 0 .375rem;
+  .edit-file-name,
+  .download-file,
+  .delete-file {
+    margin: 0 0.375rem;
   }
 
   .edit-file-name {
@@ -182,7 +206,7 @@ export function handle_rename_file_error(component: SingleInstructorFile, error:
 
 .edit-name-buttons {
   display: flex;
-  padding: .5rem 0;
+  padding: 0.5rem 0;
 }
 
 .update-file-name-button {
@@ -191,17 +215,17 @@ export function handle_rename_file_error(component: SingleInstructorFile, error:
 
 .update-file-name-cancel-button {
   @extend .flat-white-button;
-  margin-left: .625rem;
+  margin-left: 0.625rem;
 }
 
-.update-file-name-button, .update-file-name-cancel-button {
-  padding: .25rem .375rem;
+.update-file-name-button,
+.update-file-name-cancel-button {
+  padding: 0.25rem 0.375rem;
 }
 
 .display-timestamp {
   display: block;
   color: hsl(220, 20%, 65%);
-  font-size: .875rem;
+  font-size: 0.875rem;
 }
-
 </style>

--- a/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
+++ b/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
@@ -309,7 +309,7 @@ describe('InstructorFiles.vue', () => {
         wrapper.findAll('.single-instructor-file-component input').at(2).trigger('click');
         await wrapper.vm.$nextTick();
 
-        // click again to test deselect behavior 
+        // click again to test deselect behavior
         wrapper.findAll('.single-instructor-file-component input').at(2).trigger('click');
         await wrapper.vm.$nextTick();
 

--- a/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
+++ b/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
@@ -228,7 +228,7 @@ describe('InstructorFiles.vue', () => {
         expect(await view_file.vm.file_contents).toEqual(expected_content);
     });
 
-    test('Deleting a file removes it from the list of instructor files', async () => {
+    test('Delete single file', async() => {
         let delete_stub = sinon.stub(instructor_file_1, 'delete');
         delete_stub.callsFake(
             async () => InstructorFile.notify_instructor_file_deleted(instructor_file_1));
@@ -237,13 +237,95 @@ describe('InstructorFiles.vue', () => {
         wrapper.findAll('.delete-file').at(0).trigger('click');
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.find('.file-to-delete').text()).toContain(instructor_file_1.name);
+        expect(wrapper.find('.files-to-delete').findAll('li').length).toEqual(1);
+        expect(wrapper.find('.filename').text()).toContain(instructor_file_1.name);
 
         wrapper.find('.modal-delete-button').trigger('click');
         await wrapper.vm.$nextTick();
 
         expect(delete_stub.calledOnce).toBe(true);
     });
+
+    test('Delete single file while batched files are selected', async() => {
+        let delete_stub = sinon.stub(instructor_file_1, 'delete');
+        delete_stub.callsFake(
+            async () => InstructorFile.notify_instructor_file_deleted(instructor_file_1));
+
+        wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+        wrapper.findAll('.single-instructor-file-component input').at(1).trigger('click');
+        await wrapper.vm.$nextTick();
+
+
+        expect(delete_stub.callCount).toEqual(0);
+        wrapper.findAll('.delete-file').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find('.files-to-delete').findAll('li').length).toEqual(1);
+        expect(wrapper.find('.filename').text()).toContain(instructor_file_1.name);
+
+        wrapper.find('.modal-delete-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(delete_stub.calledOnce).toBe(true);
+    });
+
+    test('Delete single file using batch delete', async() => {
+        let delete_stub = sinon.stub(instructor_file_1, 'delete');
+        delete_stub.callsFake(
+            async () => InstructorFile.notify_instructor_file_deleted(instructor_file_1));
+
+        wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(delete_stub.callCount).toEqual(0);
+        wrapper.find('.batch-delete-files-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find('.files-to-delete').findAll('li').length).toEqual(1);
+        expect(wrapper.find('.filename').text()).toContain(instructor_file_1.name);
+
+        wrapper.find('.modal-delete-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(delete_stub.calledOnce).toBe(true);
+    });
+
+    test('Delete multiple files using batch delete', async() => {
+        let delete_stub1 = sinon.stub(instructor_file_1, 'delete');
+        delete_stub1.callsFake(
+            async () => InstructorFile.notify_instructor_file_deleted(instructor_file_1));
+
+        let delete_stub2 = sinon.stub(instructor_file_2, 'delete');
+        delete_stub2.callsFake(
+            async () => InstructorFile.notify_instructor_file_deleted(instructor_file_2));
+
+        expect(delete_stub1.callCount).toEqual(0);
+        expect(delete_stub2.callCount).toEqual(0);
+        wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+        wrapper.findAll('.single-instructor-file-component input').at(1).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.batch-delete-files-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find('.files-to-delete').findAll('li').length).toEqual(2);
+        expect(wrapper.findAll('.filename').at(0).text()).toContain(instructor_file_1.name);
+        expect(wrapper.findAll('.filename').at(1).text()).toContain(instructor_file_2.name);
+
+        wrapper.find('.modal-delete-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(delete_stub1.calledOnce).toBe(true);
+        expect(delete_stub2.calledOnce).toBe(true);
+    });
+
+    test('Delete all files using select all and batch delete', async() => {
+        // TODO
+
+    });
+
 
     test('Instructor file deleted while being viewed', async () => {
         let get_content_stub = sinon.stub(

--- a/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
+++ b/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
@@ -228,7 +228,7 @@ describe('InstructorFiles.vue', () => {
         expect(await view_file.vm.file_contents).toEqual(expected_content);
     });
 
-    test('Delete single file', async() => {
+    test('Delete single file', async () => {
         let delete_stub = sinon.stub(instructor_file_1, 'delete');
         delete_stub.callsFake(
             async () => InstructorFile.notify_instructor_file_deleted(instructor_file_1));
@@ -246,7 +246,7 @@ describe('InstructorFiles.vue', () => {
         expect(delete_stub.calledOnce).toBe(true);
     });
 
-    test('Delete single file while batched files are selected', async() => {
+    test('Delete single file while batched files are selected', async () => {
         let delete_stub = sinon.stub(instructor_file_1, 'delete');
         delete_stub.callsFake(
             async () => InstructorFile.notify_instructor_file_deleted(instructor_file_1));
@@ -270,7 +270,7 @@ describe('InstructorFiles.vue', () => {
         expect(delete_stub.calledOnce).toBe(true);
     });
 
-    test('Delete single file using batch delete', async() => {
+    test('Delete single file using batch delete', async () => {
         let delete_stub = sinon.stub(instructor_file_1, 'delete');
         delete_stub.callsFake(
             async () => InstructorFile.notify_instructor_file_deleted(instructor_file_1));
@@ -291,7 +291,7 @@ describe('InstructorFiles.vue', () => {
         expect(delete_stub.calledOnce).toBe(true);
     });
 
-    test('Delete multiple files using batch delete', async() => {
+    test('Delete multiple files using batch delete', async () => {
         let delete_stub1 = sinon.stub(instructor_file_1, 'delete');
         delete_stub1.callsFake(
             async () => InstructorFile.notify_instructor_file_deleted(instructor_file_1));
@@ -320,12 +320,6 @@ describe('InstructorFiles.vue', () => {
         expect(delete_stub1.calledOnce).toBe(true);
         expect(delete_stub2.calledOnce).toBe(true);
     });
-
-    test('Delete all files using select all and batch delete', async() => {
-        // TODO
-
-    });
-
 
     test('Instructor file deleted while being viewed', async () => {
         let get_content_stub = sinon.stub(

--- a/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
+++ b/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
@@ -278,6 +278,12 @@ describe('InstructorFiles.vue', () => {
         wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
         await wrapper.vm.$nextTick();
 
+        wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
         expect(delete_stub.callCount).toEqual(0);
         wrapper.find('.batch-delete-files-button').trigger('click');
         await wrapper.vm.$nextTick();
@@ -354,6 +360,30 @@ describe('InstructorFiles.vue', () => {
         wrapper.findAllComponents({name: 'SingleInstructorFile'}).at(0).trigger('click');
         await wrapper.vm.$nextTick();
         expect(get_content_stub.calledTwice).toBe(true);
+    });
+
+    test('Users have the ability to cancel the process of deleting a file', async () => {
+        let delete_stub = sinon.stub(instructor_file_1, 'delete');
+
+        wrapper.find('.delete-file').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.modal-cancel-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(delete_stub.callCount).toEqual(0);
+    });
+
+    test('API errors handled on delete', async () => {
+        sinon.stub(instructor_file_1, 'delete').rejects(new HttpError(403, "nope"));
+        wrapper.find('.delete-file').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.modal-delete-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        let api_errors = <APIErrors> wrapper.findComponent({ref: 'delete_errors'}).vm;
+        expect(api_errors.d_api_errors.length).toBe(1);
     });
 
     test('Open/close the sidebar', async () => {

--- a/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
+++ b/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
@@ -278,12 +278,6 @@ describe('InstructorFiles.vue', () => {
         wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
         await wrapper.vm.$nextTick();
 
-        wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
-        await wrapper.vm.$nextTick();
-
-        wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
-        await wrapper.vm.$nextTick();
-
         expect(delete_stub.callCount).toEqual(0);
         wrapper.find('.batch-delete-files-button').trigger('click');
         await wrapper.vm.$nextTick();
@@ -311,6 +305,12 @@ describe('InstructorFiles.vue', () => {
         wrapper.findAll('.single-instructor-file-component input').at(0).trigger('click');
         await wrapper.vm.$nextTick();
         wrapper.findAll('.single-instructor-file-component input').at(1).trigger('click');
+        await wrapper.vm.$nextTick();
+        wrapper.findAll('.single-instructor-file-component input').at(2).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        // click again to test deselect behavior 
+        wrapper.findAll('.single-instructor-file-component input').at(2).trigger('click');
         await wrapper.vm.$nextTick();
 
         wrapper.find('.batch-delete-files-button').trigger('click');

--- a/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
+++ b/tests/test_project_admin/test_instructor_files/test_instructor_files.ts
@@ -379,8 +379,8 @@ describe('InstructorFiles.vue', () => {
         wrapper.find('.delete-file').trigger('click');
         await wrapper.vm.$nextTick();
 
-        wrapper.find('.modal-delete-button').trigger('click');
-        await wrapper.vm.$nextTick();
+        await wrapper.find('.modal-delete-button').trigger('click');
+        expect(await wait_until(wrapper, w => !w.vm.d_delete_pending)).toBe(true);
 
         let api_errors = <APIErrors> wrapper.findComponent({ref: 'delete_errors'}).vm;
         expect(api_errors.d_api_errors.length).toBe(1);

--- a/tests/test_project_admin/test_instructor_files/test_single_instructor_file.ts
+++ b/tests/test_project_admin/test_instructor_files/test_single_instructor_file.ts
@@ -104,39 +104,10 @@ describe('SingleInstructorFile tests', () => {
     });
 
     test('Users have the ability to delete a file', async () => {
-        let delete_stub = sinon.stub(file_1, 'delete');
         wrapper.find('.delete-file').trigger('click');
         await component.$nextTick();
 
-        wrapper.find('.modal-delete-button').trigger('click');
-        await component.$nextTick();
-
-        expect(delete_stub.calledOnce).toBe(true);
-        expect(delete_stub.thisValues[0]).toEqual(file_1);
-    });
-
-    test('Users have the ability to cancel the process of deleting a file', async () => {
-        let delete_stub = sinon.stub(file_1, 'delete');
-
-        wrapper.find('.delete-file').trigger('click');
-        await component.$nextTick();
-
-        wrapper.find('.modal-cancel-button').trigger('click');
-        await component.$nextTick();
-
-        expect(delete_stub.callCount).toEqual(0);
-    });
-
-    test('API errors handled on delete', async () => {
-        sinon.stub(file_1, 'delete').rejects(new HttpError(403, "nope"));
-        wrapper.find('.delete-file').trigger('click');
-        await component.$nextTick();
-
-        wrapper.find('.modal-delete-button').trigger('click');
-        await component.$nextTick();
-
-        let api_errors = <APIErrors> wrapper.findComponent({ref: 'delete_errors'}).vm;
-        expect(api_errors.d_api_errors.length).toBe(1);
+        expect(wrapper.emitted().delete_requested).toBeTruthy();
     });
 
     test('Users have the ability to download a file', async () => {


### PR DESCRIPTION
In this PR we address issue https://github.com/eecs-autograder/ag-website-vue/issues/236 which describes the ability for instructors to delete available instructor files in batch instead of one-by-one. 

We preserve the single file deletion ability and additionally allow instructors to delete single files while still in batch selection mode.

This is accomplished by lifting the delete functionality and confirmation modal out of SingleInstructorFile to the parent component of InstructorFiles. The parent component manages generic deletion logic that sends delete requests asynchronously for an array of files.  When the user requests single file deletion or batch file deletion, the generic deletion mechanism is set up and then deferred to. This allows us to reduce code duplication while adding this functionality.

Note on tests: the current `develop` branch has a failing `InstructorFiles` test that this PR does not resolve

Fixes #236 