### PR TITLE
237 batch select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ag-website-vue",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ag-website-vue",
-  "version": "1.4.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/batch_select.vue
+++ b/src/components/batch_select.vue
@@ -1,0 +1,174 @@
+<template>
+  <div class="batch-select">
+    <button class="button white-button batch-select-button"
+            @click="d_show_batch_select_modal = true">
+      Batch Select
+    </button>
+    <div @click.stop>
+      <modal v-if="d_show_batch_select_modal"
+             @close="d_show_batch_select_modal = false"
+             size="large"
+             click_outside_to_close>
+        <div class="modal-header">
+          Select Items ({{ d_selected_items.length }} out of
+          {{ choices.length }} items selected)
+        </div>
+        <input class="input batch-search-field"
+               type="text"
+               placeholder="Enter a name"
+               v-model="d_batch_search_query"
+        />
+        <div>
+          <ul class="batch-select-card-grid">
+            <li class="batch-select-card"
+                :class="{
+                  selected: d_selected_items.some((el) => are_items_equal(el, item)),
+                }"
+                v-for="item of batch_filtered_items"
+                :key="item.pk"
+                @click="batch_toggle_select(item)">
+              <slot v-bind:item="item"></slot>
+            </li>
+          </ul>
+        </div>
+        <div class="button-footer-right modal-button-footer">
+          <button class="modal-confirm-button"
+                  @click="confirm_selection">
+            Confirm
+          </button>
+          <button class="modal-cancel-button"
+                  @click="d_show_batch_select_modal = false">
+            Cancel
+          </button>
+        </div>
+      </modal>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+
+import _ from 'lodash';
+
+import Modal from '@/components/modal.vue';
+
+// types for function props
+type Comparator = (lhs: unknown, rhs: unknown) => boolean;
+type Filter = (item: unknown, filter_text: string) => boolean;
+
+@Component({
+  components: {
+    Modal
+  }
+})
+export default class BatchSelect extends Vue {
+  @Prop({ required: true, type: Array })
+  choices!: unknown[];
+
+  @Prop({ type: Array })
+  value!: unknown[];
+
+  @Prop({ type: Function })
+  are_items_equal!: Comparator;
+
+  @Prop({ type: Function })
+  filter_fn!: Filter;
+
+  d_show_batch_select_modal = false;
+  d_batch_search_query: string = "";
+  d_selected_items: unknown[] = [];
+
+  created() {
+    this.d_selected_items = this.value.slice();
+  }
+
+  @Watch("value", { deep: true })
+  on_value_change(new_value: unknown[], old_value: unknown[]) {
+    this.d_selected_items = this.value.slice();
+  }
+
+  batch_toggle_select(item: unknown) {
+    if (_.some(this.d_selected_items, (el) => this.are_items_equal(el, item))) {
+      this.d_selected_items = _.filter(
+        this.d_selected_items,
+        (el) => !this.are_items_equal(el, item)
+      );
+    }
+    else {
+      this.d_selected_items.push(item);
+    }
+  }
+
+  get batch_filtered_items() {
+    return _.isEmpty(this.d_batch_search_query) ?
+      this.choices :
+      _.filter(
+        this.choices,
+        (item) => this.filter_fn(item, this.d_batch_search_query)
+      );
+  }
+
+  // Call when user clicks the "confirm" button.
+  confirm_selection() {
+    this.$emit("items_selected", this.d_selected_items);
+    this.d_show_batch_select_modal = false;
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/colors.scss';
+@import '@/styles/button_styles.scss';
+@import '@/styles/forms.scss';
+@import '@/styles/modal.scss';
+
+* {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+}
+
+.batch-select-button {
+  margin-left: 1em;
+  height: 100%;
+}
+
+.batch-search-field {
+  margin-bottom: 1em;
+  width: 100%;
+}
+
+.batch-select-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-gap: 0.5em;
+  align-items: stretch;
+  list-style-type: none;
+
+  .batch-select-card {
+    display: block;
+    padding: 1em;
+    border-radius: 3px;
+    background-color: $gray-blue-1;
+    opacity: 0.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+
+    &.selected {
+      opacity: 1;
+    }
+  }
+}
+
+/* ---------------- MODAL ---------------- */g
+
+.modal-confirm-button {
+  @extend .blue-button;
+}
+
+.modal-cancel-button {
+  @extend .white-button;
+}
+</style>

--- a/src/components/batch_select.vue
+++ b/src/components/batch_select.vue
@@ -111,8 +111,8 @@ export default class BatchSelect extends Vue {
 
   // Call when user clicks the "confirm" button.
   confirm_selection() {
-    this.$emit("items_selected", this.d_selected_items);
     this.d_show_batch_select_modal = false;
+    this.$emit("input", this.d_selected_items);
   }
 }
 </script>
@@ -162,7 +162,7 @@ export default class BatchSelect extends Vue {
   }
 }
 
-/* ---------------- MODAL ---------------- */g
+/* ---------------- MODAL ---------------- */
 
 .modal-confirm-button {
   @extend .blue-button;

--- a/src/components/project_admin/suite_settings.vue
+++ b/src/components/project_admin/suite_settings.vue
@@ -302,10 +302,6 @@ export default class SuiteSettings extends Vue {
     return file.pattern.indexOf(filter_text) >= 0;
   }
 
-  is_in_batch(file) {
-    return this.d_batch_needed_files.has(file);
-  }
-
   get instructor_files_available() {
     return this.project.instructor_files!.filter((instructor_file: InstructorFile) => {
       return this.d_suite!.instructor_files_needed.findIndex(

--- a/src/components/project_admin/suite_settings.vue
+++ b/src/components/project_admin/suite_settings.vue
@@ -39,6 +39,7 @@
       <div class="form-field-wrapper">
         <label class="label"> Sandbox environment </label>
 
+
         <select-object :items="docker_images"
                         id_field="pk"
                         v-model="d_suite.sandbox_docker_image"
@@ -89,11 +90,11 @@
             </span>
           </template>
         </dropdown-typeahead>
-        <batch-select v-model="suite.instructor_files_needed"
+        <batch-select v-model="d_suite.instructor_files_needed"
                       :choices="project.instructor_files"
                       :are_items_equal="are_files_equal"
                       :filter_fn="instructor_file_filter_fn"
-                      @items_selected="set_instructor_files($event)"
+                      @input="$emit('field_change', d_suite)"
                       v-slot="{ item }">
           {{ item.name }}
         </batch-select>
@@ -127,11 +128,11 @@
             </span>
           </template>
         </dropdown-typeahead>
-        <batch-select v-model="suite.student_files_needed"
+        <batch-select v-model="d_suite.student_files_needed"
                       :choices="project.expected_student_files"
                       :are_items_equal="are_files_equal"
                       :filter_fn="expected_student_file_filter_fn"
-                      @items_selected="set_student_files($event)"
+                      @input="$emit('field_change', d_suite)"
                       v-slot="{ item }">
           {{ item.pattern }}
         </batch-select>
@@ -230,11 +231,6 @@ export default class SuiteSettings extends Vue {
     this.$emit('field_change', this.d_suite);
   }
 
-  set_instructor_files(instructor_files: InstructorFile[]) {
-    this.d_suite!.instructor_files_needed = instructor_files;
-    this.$emit("field_change", this.d_suite);
-  }
-
   add_student_file(student_file: ExpectedStudentFile) {
     this.d_suite!.student_files_needed.push(student_file);
     this.$emit('field_change', this.d_suite);
@@ -245,11 +241,6 @@ export default class SuiteSettings extends Vue {
     lhs: InstructorFile | ExpectedStudentFile
   ) {
     return lhs.pk === rhs.pk;
-  }
-
-  set_student_files(student_files: ExpectedStudentFile[]) {
-    this.d_suite!.student_files_needed = student_files;
-    this.$emit("field_change", this.d_suite);
   }
 
   instructor_file_filter_fn(file: InstructorFile, filter_text: string) {
@@ -334,7 +325,6 @@ export default class SuiteSettings extends Vue {
 .odd-index {
   background-color: hsl(210, 20%, 96%);
 }
-
 
 .typeahead-search-bar {
   display: flex;

--- a/src/components/project_admin/suite_settings.vue
+++ b/src/components/project_admin/suite_settings.vue
@@ -422,11 +422,15 @@ export default class SuiteSettings extends Vue {
     padding: 1em;
     border-radius: 3px;
     background-color: $gray-blue-1;
+    overflow: hidden;
+    text-overflow: ellipsis;
     cursor: grabbing;
 
     &.selected {
       background-color: $ocean-blue;
+      overflow: visible;
     }
+
   }
 }
 

--- a/src/components/project_admin/suite_settings.vue
+++ b/src/components/project_admin/suite_settings.vue
@@ -113,6 +113,10 @@
 
     <fieldset class="fieldset">
       <legend class="legend"> Student Files </legend>
+      <button class="instructor-file-batch-select-button"
+              @click="start_batch_selection_mode(1)">
+        Batch Select
+      </button>
       <div class="typeahead-search-bar">
         <dropdown-typeahead ref="student_files_typeahead"
                             placeholder_text="Enter a filename"
@@ -148,7 +152,9 @@
         <div class="modal-header">Select Files</div>
         <div>
           <ul>
-            <li :class="d_batch_needed_files.some((el) => el.pk == file.pk) ? 'selected' : ''" v-for="file of d_batch_available_files" :key="file.pk" @click="batch_toggle_select(file)">{{ file.name }}</li>
+            <li :class="d_batch_needed_files.some((el) => el.pk == file.pk) ?
+'selected' : ''" v-for="file of d_batch_available_files" :key="file.pk"
+@click="batch_toggle_select(file)">{{ file.name || file.pattern }}</li>
           </ul>
         </div>
 
@@ -239,6 +245,8 @@ export default class SuiteSettings extends Vue {
   d_batch_mode : BatchModeEnum;
 
   start_batch_selection_mode(mode: BatchModeEnum) {
+    this.d_batch_mode = mode;
+
     this.d_batch_available_files = (mode == BatchModeEnum.INSTRUCTOR_FILES ? this.project.instructor_files!: this.project.expected_student_files!);
     this.d_batch_needed_files = (mode == BatchModeEnum.INSTRUCTOR_FILES ? this.d_suite!.instructor_files_needed: this.d_suite!.student_files_needed!);
 

--- a/src/components/project_admin/suite_settings.vue
+++ b/src/components/project_admin/suite_settings.vue
@@ -212,8 +212,9 @@ class Suite {
 }
 
 enum BatchModeEnum {
-  INSTRUCTOR_FILES,
-  STUDENT_FILES
+  none,
+  instructor_files,
+  student_files,
 }
 
 @Component({
@@ -243,19 +244,20 @@ export default class SuiteSettings extends Vue {
   readonly is_not_empty = is_not_empty;
 
   d_show_batch_select_modal = false;
-  d_batch_available_files: Array<InstructorFile | ExpectedStudentFile> = [];
-  d_batch_needed_files: Array<InstructorFile | ExpectedStudentFile> = [];
+  d_batch_available_files: (InstructorFile | ExpectedStudentFile)[] = [];
+  d_batch_needed_files: (InstructorFile | ExpectedStudentFile)[] = [];
   d_batch_search_query: string = "";
-  d_batch_mode: BatchModeEnum;
+  d_batch_mode: BatchModeEnum = BatchModeEnum.none;
 
   start_batch_selection_mode(mode: BatchModeEnum) {
     this.d_batch_mode = mode;
 
-    if(mode == BatchModeEnum.INSTRUCTOR_FILES) {
+    if (mode === BatchModeEnum.instructor_files) {
       this.d_batch_available_files = this.project.instructor_files!;
       this.d_batch_needed_files = this.d_suite!.instructor_files_needed;
-    } else {
-      this.d_batch_available_files =  this.project.expected_student_files!;
+    }
+    else {
+      this.d_batch_available_files = this.project.expected_student_files!;
       this.d_batch_needed_files = this.d_suite!.student_files_needed!;
     }
 
@@ -263,20 +265,22 @@ export default class SuiteSettings extends Vue {
   }
 
   batch_toggle_select(file: InstructorFile | ExpectedStudentFile) {
-    if (this.d_batch_needed_files.some((el) => el.pk == file.pk)) {
+    if (this.d_batch_needed_files.some((el) => el.pk === file.pk)) {
       this.d_batch_needed_files = this.d_batch_needed_files.filter(
         (el) => el.pk !== file.pk
       );
-    } else {
+    }
+    else {
       this.d_batch_needed_files.push(file);
     }
   }
 
   end_batch_selection_mode() {
-    if(this.d_batch_mode === BatchModeEnum.INSTRUCTOR_FILES) {
-      this.d_suite!.instructor_files_needed = this.d_batch_needed_files
-    } else {
-      this.d_suite!.student_files_needed = this.d_batch_needed_files
+    if (this.d_batch_mode === BatchModeEnum.instructor_files) {
+      this.d_suite!.instructor_files_needed = this.d_batch_needed_files as InstructorFile[];
+    }
+    else {
+      this.d_suite!.student_files_needed = this.d_batch_needed_files as ExpectedStudentFile[];
     }
     this.$emit('field_change', this.d_suite);
 
@@ -311,13 +315,20 @@ export default class SuiteSettings extends Vue {
   }
 
   get batch_filtered_files() {
-    if(this.d_batch_search_query) {
-      if(this.d_batch_mode == BatchModeEnum.INSTRUCTOR_FILES) {
-        return this.d_batch_available_files.filter((file: InstructorFile) => this.instructor_file_filter_fn(file, this.d_batch_search_query));
-      } else {
-        return this.d_batch_available_files.filter((file) => this.expected_student_file_filter_fn(file, this.d_batch_search_query));
+    if (this.d_batch_search_query) {
+      if (this.d_batch_mode === BatchModeEnum.instructor_files) {
+        return this.d_batch_available_files.filter((file) =>
+          this.instructor_file_filter_fn(file as InstructorFile, this.d_batch_search_query)
+        );
       }
-    } else {
+      else {
+        return this.d_batch_available_files.filter((file) =>
+          this.expected_student_file_filter_fn(file as ExpectedStudentFile,
+                                               this.d_batch_search_query)
+        );
+      }
+    }
+    else {
       return this.d_batch_available_files;
     }
   }
@@ -430,7 +441,6 @@ export default class SuiteSettings extends Vue {
       background-color: $ocean-blue;
       overflow: visible;
     }
-
   }
 }
 
@@ -449,5 +459,4 @@ export default class SuiteSettings extends Vue {
 .modal-cancel-button {
   @extend .red-button;
 }
-
 </style>

--- a/src/components/project_admin/suite_settings.vue
+++ b/src/components/project_admin/suite_settings.vue
@@ -433,13 +433,13 @@ export default class SuiteSettings extends Vue {
     padding: 1em;
     border-radius: 3px;
     background-color: $gray-blue-1;
+    opacity: 0.5;
     overflow: hidden;
     text-overflow: ellipsis;
-    cursor: grabbing;
+    cursor: pointer;
 
     &.selected {
-      background-color: $ocean-blue;
-      overflow: visible;
+      opacity: 1;
     }
   }
 }
@@ -453,10 +453,10 @@ export default class SuiteSettings extends Vue {
 }
 
 .modal-confirm-button {
-  @extend .green-button;
+  @extend .blue-button;
 }
 
 .modal-cancel-button {
-  @extend .red-button;
+  @extend .white-button;
 }
 </style>

--- a/src/components/project_admin/suite_settings.vue
+++ b/src/components/project_admin/suite_settings.vue
@@ -79,10 +79,6 @@
 
     <fieldset class="fieldset">
       <legend class="legend"> Instructor Files </legend>
-      <button class="instructor-file-batch-select-button"
-              @click="start_batch_selection_mode(0)">
-        Batch Select
-      </button>
       <div class="typeahead-search-bar">
         <dropdown-typeahead ref="instructor_files_typeahead"
                             placeholder_text="Enter a filename"
@@ -95,6 +91,10 @@
             </span>
           </template>
         </dropdown-typeahead>
+        <button class="button white-button batch-select-button"
+                @click="start_batch_selection_mode(BatchModeEnum.INSTRUCTOR_FILES)">
+          Batch Select
+        </button>
       </div>
 
       <div class="instructor-files">
@@ -113,10 +113,6 @@
 
     <fieldset class="fieldset">
       <legend class="legend"> Student Files </legend>
-      <button class="instructor-file-batch-select-button"
-              @click="start_batch_selection_mode(1)">
-        Batch Select
-      </button>
       <div class="typeahead-search-bar">
         <dropdown-typeahead ref="student_files_typeahead"
                             placeholder_text="Enter a filename"
@@ -129,6 +125,10 @@
             </span>
           </template>
         </dropdown-typeahead>
+        <button class="button white-button batch-select-button"
+                @click="start_batch_selection_mode(BatchModeEnum.STUDENT_FILES)">
+          Batch Select
+        </button>
       </div>
 
       <div class="student-files">
@@ -151,10 +151,12 @@
              click_outside_to_close>
         <div class="modal-header">Select Files</div>
         <div>
-          <ul>
-            <li :class="d_batch_needed_files.some((el) => el.pk == file.pk) ?
+          <ul class="batch-select-card-grid">
+            <li class="batch-select-card" :class="d_batch_needed_files.some((el) => el.pk == file.pk) ?
 'selected' : ''" v-for="file of d_batch_available_files" :key="file.pk"
-@click="batch_toggle_select(file)">{{ file.name || file.pattern }}</li>
+@click="batch_toggle_select(file)">
+          {{ file.name || file.pattern }}
+              </li>
           </ul>
         </div>
 
@@ -209,7 +211,6 @@ class Suite {
   }
 }
 
-type UnionFile = ExpectedStudentFile | InstructorFile;
 enum BatchModeEnum {
   INSTRUCTOR_FILES,
   STUDENT_FILES
@@ -235,13 +236,15 @@ export default class SuiteSettings extends Vue {
   @Prop({required: true})
   docker_images!: SandboxDockerImageData[];
 
+  BatchModeEnum = BatchModeEnum;
+
   d_suite: Suite | null = null;
 
   readonly is_not_empty = is_not_empty;
 
   d_show_batch_select_modal = false;
-  d_batch_available_files: UnionFile[]  = new Array<UnionFile>();
-  d_batch_needed_files: UnionFile[] = new Array<UnionFile>();
+  d_batch_available_files: File[]  = new Array<File>();
+  d_batch_needed_files: File[] = new Array<File>();
   d_batch_mode : BatchModeEnum;
 
   start_batch_selection_mode(mode: BatchModeEnum) {
@@ -253,7 +256,7 @@ export default class SuiteSettings extends Vue {
     this.d_show_batch_select_modal = true;
   }
 
-  batch_toggle_select(file: UnionFile) {
+  batch_toggle_select(file: File) {
     if(this.d_batch_needed_files.some((el) => el.pk == file.pk)) {
       this.d_batch_needed_files = this.d_batch_needed_files.filter(el => el.pk !== file.pk);
     } else {
@@ -327,7 +330,6 @@ export default class SuiteSettings extends Vue {
 @import '@/styles/forms.scss';
 @import '@/styles/modal.scss';
 
-
 * {
   box-sizing: border-box;
   padding: 0;
@@ -378,9 +380,38 @@ export default class SuiteSettings extends Vue {
   background-color: hsl(210, 20%, 96%);
 }
 
-/* TODO: get rid of dev stuff */
-.selected {
-  color: red;
+
+.typeahead-search-bar {
+  display: flex;
+
+  .dropdown-typeahead-container {
+    flex: 1;
+  }
+
+  .batch-select-button {
+    margin-left: 1em;
+  }
+}
+
+
+.batch-select-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-gap: 0.5em;
+  align-items: stretch;
+  list-style-type: none;
+
+  .batch-select-card {
+    display: block;
+    padding: 1em;
+    border-radius: 3px;
+    background-color: $gray-blue-1;
+    cursor: grabbing;
+
+    &.selected {
+      background-color: $ocean-blue;
+    }
+  }
 }
 
 

--- a/src/components/project_admin/suite_settings.vue
+++ b/src/components/project_admin/suite_settings.vue
@@ -307,11 +307,14 @@ export default class SuiteSettings extends Vue {
   }
 
   instructor_file_filter_fn(file: InstructorFile, filter_text: string) {
-    return file.name.indexOf(filter_text) >= 0;
+    return file.name.toLowerCase().indexOf(filter_text.toLowerCase()) >= 0;
   }
 
-  expected_student_file_filter_fn(file: ExpectedStudentFile, filter_text: string) {
-    return file.pattern.indexOf(filter_text) >= 0;
+  expected_student_file_filter_fn(
+    file: ExpectedStudentFile,
+    filter_text: string
+  ) {
+    return file.pattern.toLowerCase().indexOf(filter_text.toLowerCase()) >= 0;
   }
 
   get batch_filtered_files() {

--- a/tests/test_batch_select.ts
+++ b/tests/test_batch_select.ts
@@ -36,7 +36,7 @@ let selected: TestObj[] = [obj1];
                      :choices="objects"
                      :are_items_equal="are_items_equal"
                      :filter_fn="filter_fn"
-                     @items_selected="items_selected($event)"
+                     @input="on_input($event)"
                      v-slot="{ item }"
                      ref="batch_select"
                  >
@@ -62,7 +62,7 @@ class WrapperComponent extends Vue {
         return lhs.value === rhs.value;
     }
 
-    items_selected(object: TestObj) {}
+    on_input(object: TestObj) {}
 
     change_selected() {
         this.selected = [obj3];
@@ -72,11 +72,11 @@ class WrapperComponent extends Vue {
 describe('BatchSelect', () => {
     let wrapper: Wrapper<WrapperComponent>;
     let batch_select_wrapper: Wrapper<BatchSelect>;
-    let items_selected_spy: sinon.SinonSpy;
+    let on_input_spy: sinon.SinonSpy;
 
     beforeEach(() => {
         wrapper = managed_mount(WrapperComponent);
-        items_selected_spy = sinon.spy(wrapper.vm, 'items_selected');
+        on_input_spy = sinon.spy(wrapper.vm, 'on_input');
         batch_select_wrapper = wrapper.findComponent({ref: 'batch_select'}) as Wrapper<BatchSelect>;
     });
 
@@ -95,9 +95,6 @@ describe('BatchSelect', () => {
 
         batch_select_wrapper.findAll('.modal-cancel-button').at(0).trigger('click');
         await batch_select_wrapper.vm.$nextTick();
-
-        expect(batch_select_wrapper.vm.d_show_batch_select_modal).toBe(false);
-
     });
 
     test('closes the modal after clicking close', async () => {
@@ -120,8 +117,8 @@ describe('BatchSelect', () => {
         batch_select_wrapper.find('.modal-confirm-button').trigger('click');
         await batch_select_wrapper.vm.$nextTick();
 
-        expect(emitted(batch_select_wrapper, 'items_selected')[0][0]).toEqual([obj1, obj2]);
-        expect(items_selected_spy.calledWith([obj1, obj2])).toBe(true);
+        expect(emitted(batch_select_wrapper, 'input')[0][0]).toEqual([obj1, obj2]);
+        expect(on_input_spy.calledWith([obj1, obj2])).toBe(true);
     });
 
     test('removes the selected item after selected again', async () => {
@@ -134,8 +131,8 @@ describe('BatchSelect', () => {
         batch_select_wrapper.find('.modal-confirm-button').trigger('click');
         await batch_select_wrapper.vm.$nextTick();
 
-        expect(emitted(batch_select_wrapper, 'items_selected')[0][0]).toEqual([]);
-        expect(items_selected_spy.calledWith([])).toBe(true);
+        expect(emitted(batch_select_wrapper, 'input')[0][0]).toEqual([]);
+        expect(on_input_spy.calledWith([])).toBe(true);
     });
 
     test('displays the object by slot attribute', async () => {

--- a/tests/test_batch_select.ts
+++ b/tests/test_batch_select.ts
@@ -95,6 +95,9 @@ describe('BatchSelect', () => {
 
         batch_select_wrapper.findAll('.modal-cancel-button').at(0).trigger('click');
         await batch_select_wrapper.vm.$nextTick();
+
+        expect(batch_select_wrapper.vm.d_show_batch_select_modal).toBe(false);
+
     });
 
     test('closes the modal after clicking close', async () => {

--- a/tests/test_batch_select.ts
+++ b/tests/test_batch_select.ts
@@ -95,6 +95,8 @@ describe('BatchSelect', () => {
 
         batch_select_wrapper.findAll('.modal-cancel-button').at(0).trigger('click');
         await batch_select_wrapper.vm.$nextTick();
+
+        expect(batch_select_wrapper.vm.d_show_batch_select_modal).toBe(false);
     });
 
     test('closes the modal after clicking close', async () => {

--- a/tests/test_batch_select.ts
+++ b/tests/test_batch_select.ts
@@ -1,0 +1,177 @@
+import Vue from "vue";
+import Component from "vue-class-component";
+
+import { Wrapper } from '@vue/test-utils';
+
+import _ from 'lodash';
+import * as sinon from 'sinon';
+
+import BatchSelect from "@/components/batch_select.vue";
+
+import { managed_mount } from '@/tests/setup';
+import { emitted } from '@/tests/utils';
+
+
+interface TestObj {
+    value: string;
+}
+
+let obj1: TestObj = {
+    value: "objectA-a"
+};
+let obj2: TestObj = {
+    value: "objectA-b"
+};
+let obj3: TestObj = {
+    value: "otherObject"
+};
+
+let objects: TestObj[] = [obj1, obj2, obj3];
+let selected: TestObj[] = [obj1];
+
+@Component({
+    template: `<div>
+                 <batch-select
+                     v-model="selected"
+                     :choices="objects"
+                     :are_items_equal="are_items_equal"
+                     :filter_fn="filter_fn"
+                     @items_selected="items_selected($event)"
+                     v-slot="{ item }"
+                     ref="batch_select"
+                 >
+                     {{ item.value }}
+                 </batch-select>
+                 <div class="change-selected"
+                      @click="change_selected">
+                 </div>
+               </div>`,
+    components: {
+        'batch-select': BatchSelect
+    }
+})
+class WrapperComponent extends Vue {
+    objects: TestObj[] = objects;
+    selected: TestObj[] = selected;
+
+    filter_fn(obj: TestObj, filter_text: string) {
+        return _.includes(obj.value, filter_text);
+    }
+
+    are_items_equal(lhs: TestObj, rhs: TestObj) {
+        return lhs.value === rhs.value;
+    }
+
+    items_selected(object: TestObj) {}
+
+    change_selected() {
+        this.selected = [obj3];
+    }
+}
+
+describe('BatchSelect', () => {
+    let wrapper: Wrapper<WrapperComponent>;
+    let batch_select_wrapper: Wrapper<BatchSelect>;
+    let items_selected_spy: sinon.SinonSpy;
+
+    beforeEach(() => {
+        wrapper = managed_mount(WrapperComponent);
+        items_selected_spy = sinon.spy(wrapper.vm, 'items_selected');
+        batch_select_wrapper = wrapper.findComponent({ref: 'batch_select'}) as Wrapper<BatchSelect>;
+    });
+
+    test('sets d_selected_items to a deep copy of value', async () => {
+        expect(batch_select_wrapper.vm.d_selected_items).toEqual(selected);
+        expect(batch_select_wrapper.vm.d_selected_items).not.toBe(selected);
+    });
+
+    test('closes the modal after cancelling', async () => {
+        expect(batch_select_wrapper.vm.d_show_batch_select_modal).toBe(false);
+
+        batch_select_wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        expect(batch_select_wrapper.vm.d_show_batch_select_modal).toBe(true);
+
+        batch_select_wrapper.findAll('.modal-cancel-button').at(0).trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+    });
+
+    test('closes the modal after clicking close', async () => {
+        batch_select_wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        batch_select_wrapper.findAll('.close-button').at(0).trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        expect(batch_select_wrapper.vm.d_show_batch_select_modal).toBe(false);
+    });
+
+    test('adds the item after selected', async () => {
+        batch_select_wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        batch_select_wrapper.findAll('.batch-select-card').at(1).trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        batch_select_wrapper.find('.modal-confirm-button').trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        expect(emitted(batch_select_wrapper, 'items_selected')[0][0]).toEqual([obj1, obj2]);
+        expect(items_selected_spy.calledWith([obj1, obj2])).toBe(true);
+    });
+
+    test('removes the selected item after selected again', async () => {
+        batch_select_wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        batch_select_wrapper.findAll('.batch-select-card').at(0).trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        batch_select_wrapper.find('.modal-confirm-button').trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        expect(emitted(batch_select_wrapper, 'items_selected')[0][0]).toEqual([]);
+        expect(items_selected_spy.calledWith([])).toBe(true);
+    });
+
+    test('displays the object by slot attribute', async () => {
+        batch_select_wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        const cards = batch_select_wrapper.findAll('.batch-select-card');
+        await batch_select_wrapper.vm.$nextTick();
+
+        _.each(_.range(selected.length), (index) => {
+           expect(cards.at(index).text()).toEqual(objects[index].value);
+        });
+    });
+
+    test('filters items', async () => {
+        let filter_param = 'objectA';
+        let filter_objs = [obj1, obj2];
+
+        batch_select_wrapper.find('.batch-select-button').trigger('click');
+        await batch_select_wrapper.vm.$nextTick();
+
+        expect(batch_select_wrapper.vm.batch_filtered_items).toEqual(objects);
+
+        await batch_select_wrapper.find('.batch-search-field').setValue(filter_param);
+        await batch_select_wrapper.vm.$nextTick();
+
+        const cards = batch_select_wrapper.findAll('.batch-select-card');
+        await batch_select_wrapper.vm.$nextTick();
+
+        expect(batch_select_wrapper.vm.batch_filtered_items).toEqual(filter_objs);
+        _.each(_.range(filter_objs.length), (index) => {
+            expect(cards.at(index).text()).toEqual(filter_objs[index].value);
+        });
+    });
+
+    test('updates selected after the prop value is updated', async () => {
+       wrapper.find('.change-selected').trigger('click');
+       await wrapper.vm.$nextTick();
+
+       expect(batch_select_wrapper.vm.d_selected_items).toEqual([obj3]);
+    });
+});

--- a/tests/test_project_admin/test_suite_settings.ts
+++ b/tests/test_project_admin/test_suite_settings.ts
@@ -395,4 +395,49 @@ describe('Field binding tests', () => {
 
         expect(emitted(wrapper, 'field_change')[0][0]).toEqual(wrapper.vm.d_suite);
     });
+
+    test('Adding instructor file using batch select', async () => {
+        expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
+        
+        wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.findAll('.batch-select-card').at(2).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.modal-confirm-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(3);
+    });
+
+    test('Removing instructor file using batch select', async () => {
+        expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
+        
+        wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.findAll('.batch-select-card').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.modal-confirm-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(1);
+    });
+
+    test('Cancelling instructor file batch select preserves state', async () => {
+        expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
+        
+        wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.findAll('.batch-select-card').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.modal-cancel-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
+    });
 });

--- a/tests/test_project_admin/test_suite_settings.ts
+++ b/tests/test_project_admin/test_suite_settings.ts
@@ -427,7 +427,6 @@ describe('Field binding tests', () => {
             f.name.toLowerCase() === test_input.toLowerCase()).length);
     });
 
-
     test('Removing instructor file using batch select', async () => {
         expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
 

--- a/tests/test_project_admin/test_suite_settings.ts
+++ b/tests/test_project_admin/test_suite_settings.ts
@@ -398,7 +398,7 @@ describe('Field binding tests', () => {
 
     test('Adding instructor file using batch select', async () => {
         expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
-        
+
         wrapper.findAll('.batch-select-button').at(0).trigger('click');
         await wrapper.vm.$nextTick();
 
@@ -413,7 +413,7 @@ describe('Field binding tests', () => {
 
     test('Removing instructor file using batch select', async () => {
         expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
-        
+
         wrapper.findAll('.batch-select-button').at(0).trigger('click');
         await wrapper.vm.$nextTick();
 
@@ -428,7 +428,7 @@ describe('Field binding tests', () => {
 
     test('Cancelling instructor file batch select preserves state', async () => {
         expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
-        
+
         wrapper.findAll('.batch-select-button').at(0).trigger('click');
         await wrapper.vm.$nextTick();
 

--- a/tests/test_project_admin/test_suite_settings.ts
+++ b/tests/test_project_admin/test_suite_settings.ts
@@ -412,16 +412,17 @@ describe('Field binding tests', () => {
     });
 
     test('InstructorFile filter function on batch select', async () => {
-        wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        wrapper.find('.batch-select-button').trigger('click');
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.findAll('.batch-select-card').length).toBe(3);
+        expect(wrapper.findAll('.batch-select-card').length).toBe(project.instructor_files.length);
 
-        wrapper.findAll('.batch-search-field').at(0).setValue('wa');
+        let test_input = project.instructor_files[0].name;
+        await wrapper.find('.batch-search-field').setValue(test_input)
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.findAll('.batch-select-card').length).toBe(1);
-        expect(wrapper.findAll('.batch-select-card').at(0).text()).toBe(instructor_file_3.name);
+        expect(wrapper.findAll('.batch-select-card').length).
+          toBe(project.instructor_files.filter(f => f.name === test_input).length);
     });
 
 
@@ -474,13 +475,16 @@ describe('Field binding tests', () => {
         wrapper.findAll('.batch-select-button').at(1).trigger('click');
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.findAll('.batch-select-card').length).toBe(3);
+        expect(wrapper.findAll('.batch-select-card').length).
+          toBe(project.expected_student_files.length);
 
-        wrapper.findAll('.batch-search-field').at(0).setValue('ep');
+        let test_input = project.instructor_files[0].name;
+        await wrapper.find('.batch-search-field').setValue(test_input);
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.findAll('.batch-select-card').length).toBe(1);
-        expect(wrapper.findAll('.batch-select-card').at(0).text()).toBe(student_file_1.pattern);
+        expect(wrapper.findAll('.batch-select-card').length).toBe(
+          project.expected_student_files.filter(f => f.name === test_input).length
+        );
     });
 
     test('Removing student file using batch select', async () => {

--- a/tests/test_project_admin/test_suite_settings.ts
+++ b/tests/test_project_admin/test_suite_settings.ts
@@ -411,6 +411,20 @@ describe('Field binding tests', () => {
         expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(3);
     });
 
+    test('InstructorFile filter function on batch select', async () => {
+        wrapper.findAll('.batch-select-button').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.findAll('.batch-select-card').length).toBe(3);
+
+        wrapper.findAll('.batch-search-field').at(0).setValue('wa');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.findAll('.batch-select-card').length).toBe(1);
+        expect(wrapper.findAll('.batch-select-card').at(0).text()).toBe(instructor_file_3.name);
+    });
+
+
     test('Removing instructor file using batch select', async () => {
         expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
 
@@ -439,5 +453,63 @@ describe('Field binding tests', () => {
         await wrapper.vm.$nextTick();
 
         expect(wrapper.vm.d_suite!.instructor_files_needed.length).toEqual(2);
+    });
+
+    test('Adding student file using batch select', async () => {
+        expect(wrapper.vm.d_suite!.student_files_needed.length).toEqual(2);
+
+        wrapper.findAll('.batch-select-button').at(1).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.findAll('.batch-select-card').at(2).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.modal-confirm-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.d_suite!.student_files_needed.length).toEqual(3);
+    });
+
+    test('ExpectedStudentFile filter function on batch select', async () => {
+        wrapper.findAll('.batch-select-button').at(1).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.findAll('.batch-select-card').length).toBe(3);
+
+        wrapper.findAll('.batch-search-field').at(0).setValue('ep');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.findAll('.batch-select-card').length).toBe(1);
+        expect(wrapper.findAll('.batch-select-card').at(0).text()).toBe(student_file_1.pattern);
+    });
+
+    test('Removing student file using batch select', async () => {
+        expect(wrapper.vm.d_suite!.student_files_needed.length).toEqual(2);
+
+        wrapper.findAll('.batch-select-button').at(1).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.findAll('.batch-select-card').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.modal-confirm-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.d_suite!.student_files_needed.length).toEqual(1);
+    });
+
+    test('Cancelling instructor file batch select preserves state', async () => {
+        expect(wrapper.vm.d_suite!.student_files_needed.length).toEqual(2);
+
+        wrapper.findAll('.batch-select-button').at(1).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.findAll('.batch-select-card').at(0).trigger('click');
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.modal-cancel-button').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.d_suite!.student_files_needed.length).toEqual(2);
     });
 });

--- a/tests/test_project_admin/test_suite_settings.ts
+++ b/tests/test_project_admin/test_suite_settings.ts
@@ -422,7 +422,8 @@ describe('Field binding tests', () => {
         await wrapper.vm.$nextTick();
 
         expect(wrapper.findAll('.batch-select-card').length).
-          toBe(project.instructor_files.filter(f => f.name === test_input).length);
+          toBe(project.instructor_files.filter(f => 
+            f.name.toLowerCase() === test_input.toLowerCase()).length);
     });
 
 

--- a/tests/test_project_admin/test_suite_settings.ts
+++ b/tests/test_project_admin/test_suite_settings.ts
@@ -415,14 +415,15 @@ describe('Field binding tests', () => {
         wrapper.find('.batch-select-button').trigger('click');
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.findAll('.batch-select-card').length).toBe(project.instructor_files.length);
+        expect(wrapper.findAll('.batch-select-card').length).toBe(
+            project!.instructor_files!.length);
 
-        let test_input = project.instructor_files[0].name;
-        await wrapper.find('.batch-search-field').setValue(test_input)
+        let test_input = project!.instructor_files![0].name;
+        await wrapper.find('.batch-search-field').setValue(test_input);
         await wrapper.vm.$nextTick();
 
         expect(wrapper.findAll('.batch-select-card').length).
-          toBe(project.instructor_files.filter(f => 
+          toBe(project.instructor_files!.filter(f =>
             f.name.toLowerCase() === test_input.toLowerCase()).length);
     });
 
@@ -479,12 +480,12 @@ describe('Field binding tests', () => {
         expect(wrapper.findAll('.batch-select-card').length).
           toBe(project.expected_student_files.length);
 
-        let test_input = project.instructor_files[0].name;
+        let test_input = project!.instructor_files![0].name;
         await wrapper.find('.batch-search-field').setValue(test_input);
         await wrapper.vm.$nextTick();
 
         expect(wrapper.findAll('.batch-select-card').length).toBe(
-          project.expected_student_files.filter(f => f.name === test_input).length
+          project.expected_student_files.filter(f => f.pattern === test_input).length
         );
     });
 


### PR DESCRIPTION
In this PR we address #237 to allow instructors to select required files for test suites in batch.

During our design phase, we decided that implementing this functionality on top of the existing dropdown typeahead system would result in a clunky UI.

Instead, our alternative is to present a batch selection mode that complements the typeahead instead of replaces it. The existing typeahead remains identical, except now instructors have a `Batch Select` button to the right of the typeahead:

![Screen Shot 2020-12-13 at 7 33 35 PM](https://user-images.githubusercontent.com/16354853/102028875-2cb07b80-3d7a-11eb-94d5-4a19da472d69.png)

Clicking this button opens up a modified modal component that provides a filter & select mechanism for batch mode.

![Screen Shot 2020-12-13 at 7 35 33 PM](https://user-images.githubusercontent.com/16354853/102028929-641f2800-3d7a-11eb-9edb-e965ec1264de.png)

The darkened cards represent those required by the suite, while the lighter ones represent all the options the user has. 

After the user confirms their selection, the required files are updated to represent the user's choices from the GUI.

The way this was accomplished was by introducing a unified search and select modal UI that could be launched by either the batch select for instructor files or the batch select for student files. To launch the UI, `start_batch_selection_mode` should be called. When the user presses confirm, `end_batch_selection_mode` is called. The cancel button does not result in the user losing their batch selection, it simply hides the UI.

This PR passes all relevant tests, and new tests are added to ensure batch selection functionality. We meet the global coverage requirements in the Travis build.

Fixes #237 