### PR TITLE
Change AG test case advanced settings to always be visible

### DIFF
--- a/src/components/project_admin/ag_tests/ag_test_case_panel.vue
+++ b/src/components/project_admin/ag_tests/ag_test_case_panel.vue
@@ -20,7 +20,7 @@
               <i class="fas fa-plus"></i>
               <span class="menu-item-text">Add command</span>
             </div>
-            <template v-if="ag_test_case.ag_test_commands.length > 1">
+            <template>
               <div class="menu-divider"> </div>
               <div ref="edit_ag_test_case_menu_item"
                   @click="d_show_ag_test_case_settings_modal = true"

--- a/src/components/project_admin/ag_tests/ag_test_case_settings.vue
+++ b/src/components/project_admin/ag_tests/ag_test_case_settings.vue
@@ -13,8 +13,7 @@
         </validated-input>
       </div>
 
-      <div v-if="d_ag_test_case.ag_test_commands.length > 1"
-           ref="fdbk_panels">
+      <div ref="fdbk_panels">
         <AGTestCaseFdbkConfigPanel ref="normal"
                                    v-model="d_ag_test_case.normal_fdbk_config"
                                    :config_name="FeedbackConfigLabel.normal">

--- a/tests/test_project_admin/test_ag_tests/test_ag_test_case_settings.ts
+++ b/tests/test_project_admin/test_ag_tests/test_ag_test_case_settings.ts
@@ -107,11 +107,9 @@ describe('AG test case settings form tests', () => {
         expect(api_errors.d_api_errors.length).toBe(1);
     });
 
-    test('FeedbackCongfigAGCase component only available when ag_test_case has more than ' +
-         'one command',
-         async () => {
+    test('Feedback config panels always visible', async () => {
         expect(component.d_ag_test_case!.ag_test_commands.length).toEqual(0);
-        expect(wrapper.findComponent({ref: 'fdbk_panels'}).exists()).toBe(false);
+        expect(wrapper.findComponent({ref: 'fdbk_panels'}).exists()).toBe(true);
 
         wrapper.setProps({ag_test_case: ag_case_with_multiple_commands});
         await component.$nextTick();
@@ -128,7 +126,7 @@ describe('AG test case settings form tests', () => {
         await component.$nextTick();
 
         expect(component.d_ag_test_case!.ag_test_commands.length).toEqual(1);
-        expect(wrapper.findComponent({ref: 'fdbk_panels'}).exists()).toBe(false);
+        expect(wrapper.findComponent({ref: 'fdbk_panels'}).exists()).toBe(true);
     });
 
     test('update config settings in ag_case_config_panel - changes reflected in ' +


### PR DESCRIPTION
This will let us avoid the scenario where a multi-command test later becomes single-command and the user can't edit the test case settings anymore.