### PR TITLE
Add zooming and panning to 'over time' graphs, update xtick timestamp format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6768,6 +6768,14 @@
         "color-name": "^1.0.0"
       }
     },
+    "chartjs-plugin-zoom": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-zoom/-/chartjs-plugin-zoom-0.7.7.tgz",
+      "integrity": "sha512-8fOHPPiZTT2+K0w278TQWYs/DtPg06s1OpTqdXxPpdfH7QQbl6Io/WuE1FjPehDWVCxpe3tSTts+dPbxgq2Z5g==",
+      "requires": {
+        "hammerjs": "^2.0.8"
+      }
+    },
     "check-types": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
@@ -10441,6 +10449,11 @@
           "dev": true
         }
       }
+    },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "handle-thing": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/minimatch": "^3.0.3",
     "ag-client-typescript": "2.4.3",
     "chart.js": "^2.9.3",
+    "chartjs-plugin-zoom": "^0.7.7",
     "file-saver": "^2.0.1",
     "lodash": "^4.17.19",
     "minimatch": "^3.0.4",

--- a/src/components/project_admin/project_stats/first_submission_time_vs_final_score.ts
+++ b/src/components/project_admin/project_stats/first_submission_time_vs_final_score.ts
@@ -2,6 +2,8 @@ import { Scatter } from 'vue-chartjs';
 import { Component, Mixins, Prop, Watch } from 'vue-property-decorator';
 
 import { FullUltimateSubmissionResult } from 'ag-client-typescript';
+// @ts-ignore
+import zoom from 'chartjs-plugin-zoom';
 
 import { SafeMap } from '@/safe_map';
 
@@ -18,6 +20,7 @@ export default class FirstSubmissionTimeVsFinalScore extends Mixins(Scatter) {
     first_submissions_by_group!: SafeMap<number, FirstSubmissionData>;
 
     mounted() {
+        this.addPlugin(zoom);
         this.update_chart();
     }
 
@@ -46,12 +49,12 @@ export default class FirstSubmissionTimeVsFinalScore extends Mixins(Scatter) {
                     xAxes: [{
                         type: 'time',
                         time: {
+                            unit: 'hour',
+                            unitStepSize: 1,
                             displayFormats: {
-                                // Don't display seconds or milliseconds.
-                                millisecond: 'h:mm a',
-                                second: 'h:mm a',
+                                hour: 'MMM D, h:mm a',
                             },
-                            tooltipFormat: 'MMM D, YYYY, h:mm a'
+                            tooltipFormat: 'MMM D, YYYY, h:mm a',
                         },
                         distribution: 'linear',
                         bounds: 'data',
@@ -74,6 +77,18 @@ export default class FirstSubmissionTimeVsFinalScore extends Mixins(Scatter) {
                             labelString: '% Score'
                         }
                     }]
+                },
+                plugins: {
+                    zoom: {
+                        pan: {
+                            enabled: true,
+                            mode: 'x',
+                        },
+                        zoom: {
+                            enabled: true,
+                            mode: 'x',
+                        }
+                    },
                 }
             }
         );

--- a/src/components/project_admin/project_stats/submissions_over_time_graph.ts
+++ b/src/components/project_admin/project_stats/submissions_over_time_graph.ts
@@ -1,8 +1,9 @@
-// CommitChart.ts
 import { Line } from 'vue-chartjs';
 import { Component, Mixins, Prop, Watch } from 'vue-property-decorator';
 
 import { Submission } from 'ag-client-typescript';
+// @ts-ignore
+import zoom from 'chartjs-plugin-zoom';
 // @ts-ignore
 import moment from "moment";
 
@@ -14,6 +15,7 @@ export default class SubmissionsOverTimeGraph extends Mixins(Line) {
     submissions!: Submission[];
 
     mounted() {
+        this.addPlugin(zoom);
         this.update_chart();
     }
 
@@ -42,12 +44,12 @@ export default class SubmissionsOverTimeGraph extends Mixins(Line) {
                     xAxes: [{
                         type: 'time',
                         time: {
+                            unit: 'hour',
+                            unitStepSize: 1,
                             displayFormats: {
-                                // Don't display seconds or milliseconds.
-                                millisecond: 'h:mm a',
-                                second: 'h:mm a',
+                                hour: 'MMM D, h:mm a',
                             },
-                            tooltipFormat: 'MMM D, YYYY, h:mm a'
+                            tooltipFormat: 'MMM D, YYYY, h:mm a',
                         },
                         distribution: 'linear',
                         bounds: 'data',
@@ -70,6 +72,18 @@ export default class SubmissionsOverTimeGraph extends Mixins(Line) {
                             labelString: '# of Submissions'
                         }
                     }]
+                },
+                plugins: {
+                    zoom: {
+                        pan: {
+                            enabled: true,
+                            mode: 'x',
+                        },
+                        zoom: {
+                            enabled: true,
+                            mode: 'x',
+                        }
+                    },
                 }
             }
         );


### PR DESCRIPTION
Addresses feedback from https://github.com/eecs-autograder/autograder.io/issues/4#issuecomment-771141926