### PR TITLE
Add timezone selector to datetime picker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
 
-dist: bionic
 language: python
 python: 3.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 
+dist: bionic
 language: python
 python: 3.6
 

--- a/src/components/datetime/datetime_picker.vue
+++ b/src/components/datetime/datetime_picker.vue
@@ -35,10 +35,22 @@
       </div>
     </div>
 
-    <time-picker v-model="d_time"
-                 @input="update_time_selected"
-                 ref="time_picker"
-                 class="time-picker"></time-picker>
+    <div class="time-column">
+      <time-picker v-model="d_time"
+                  @input="update_time_selected"
+                  ref="time_picker"></time-picker>
+
+      <select
+        :value="d_timezone"
+        @change="update_timezone_selected"
+        data-testid="timezone-select"
+        class="select timezone-select"
+      >
+        <option v-for="timezone of timezones" :value="timezone" :key="timezone">
+          {{timezone}}
+        </option>
+      </select>
+    </div>
   </div>
 </template>
 
@@ -49,6 +61,7 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import moment from 'moment';
 
 import TimePicker from "@/components/datetime/time_picker.vue";
+import { assert_not_null } from '@/utils';
 
 @Component({
   components: {
@@ -76,6 +89,8 @@ export default class DatetimePicker extends Vue {
 
   d_month = moment().month();  // The current month shown on the calendar
   d_year = moment().year();  // The current year shown on the calendar
+
+  d_timezone: string | null = null;
 
   calendar: number[][] = [
     [0, 0, 0, 0, 0, 0, 0],
@@ -115,6 +130,13 @@ export default class DatetimePicker extends Vue {
       this.d_selected_month = this.d_date.month();
       this.d_selected_year = this.d_date.year();
     }
+    // We only want to guess the timezone the first time this component
+    // instance is inintalized, so that when the user changes the timezone
+    // it shows their selected datetime in that timezone unless they refresh
+    // the page.
+    this.d_timezone = this.d_timezone ?? moment.tz.guess();
+
+    this.d_date.tz(this.d_timezone, false);
 
     this.d_time = moment({hours: this.d_date.hours(),
                           minutes: this.d_date.minutes()}).format('HH:mm');
@@ -195,6 +217,18 @@ export default class DatetimePicker extends Vue {
     }
   }
 
+  update_timezone_selected(event: Event) {
+    let timezone = event?.target?.value;
+    assert_not_null(timezone);
+    this.d_timezone = timezone;
+    this.d_date = this.d_date.tz(timezone, true);
+    this.$emit('input', this.d_date.format());
+  }
+
+  get timezones() {
+    return moment.tz.names();
+  }
+
   readonly months = [
     "January",
     "February",
@@ -250,7 +284,7 @@ export class InvalidDatetimeStrError extends Error {
   flex-wrap: wrap;
 }
 
-.calendar, .time-picker {
+.calendar, .time-column {
   border: 1px solid $pebble-dark;
   border-radius: 2px;
 }
@@ -274,7 +308,7 @@ export class InvalidDatetimeStrError extends Error {
   display: flex;
   flex-wrap: nowrap;
   font-weight: bold;
-  justify-content: space-evenly;
+  justify-content: space-between;
   align-items: center;
   padding: .5rem .75rem;
 }
@@ -347,13 +381,19 @@ export class InvalidDatetimeStrError extends Error {
 
 // TIMEPICKER ***********************************************************
 
-.time-picker {
+.time-column {
   display: flex;
   flex-direction: column;
   justify-content: center;
 
-  width: 100%;
-  max-width: 210px;
+  padding: 1rem;
+
+  // width: 100%;
+  // max-width: 210px;
+}
+
+.timezone-select {
+  margin-top: .5rem;
 }
 
 </style>

--- a/src/components/datetime/datetime_picker.vue
+++ b/src/components/datetime/datetime_picker.vue
@@ -57,11 +57,13 @@
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
-// @ts-ignore
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import TimePicker from "@/components/datetime/time_picker.vue";
-import { assert_not_null } from '@/utils';
+
+interface HTMLInputEvent extends Event {
+  target: HTMLInputElement & EventTarget;
+}
 
 @Component({
   components: {
@@ -217,11 +219,9 @@ export default class DatetimePicker extends Vue {
     }
   }
 
-  update_timezone_selected(event: Event) {
-    let timezone = event?.target?.value;
-    assert_not_null(timezone);
-    this.d_timezone = timezone;
-    this.d_date = this.d_date.tz(timezone, true);
+  update_timezone_selected(event: HTMLInputEvent) {
+    this.d_timezone = event.target.value;
+    this.d_date = this.d_date.tz(this.d_timezone, true);
     this.$emit('input', this.d_date.format());
   }
 

--- a/src/components/datetime/time_picker.vue
+++ b/src/components/datetime/time_picker.vue
@@ -1,61 +1,59 @@
 <template>
   <div class="timepicker">
-    <div class="timepicker-header">
 
-      <div class="time-unit-col">
-        <button type="button"
-                data-testid="next_hour_button"
-                @click="go_to_next_hour"
-                class="up-button">
-          <i class="fas fa-chevron-up up-arrow"></i>
-        </button>
-        <div>
-          <input type="text"
-                 data-testid="hour_input"
-                 class="hour-input"
-                 :value="hours_str"
-                 @keydown="update_hours">
-        </div>
-        <button type="button"
-                data-testid="prev_hour_button"
-                @click="go_to_prev_hour"
-                class="down-button">
-          <i class="fas fa-chevron-down down-arrow"></i>
-        </button>
+    <div class="time-unit-col">
+      <button type="button"
+              data-testid="next_hour_button"
+              @click="go_to_next_hour"
+              class="up-button">
+        <i class="fas fa-chevron-up up-arrow"></i>
+      </button>
+      <div>
+        <input type="text"
+                data-testid="hour_input"
+                class="hour-input"
+                :value="hours_str"
+                @keydown="update_hours">
       </div>
+      <button type="button"
+              data-testid="prev_hour_button"
+              @click="go_to_prev_hour"
+              class="down-button">
+        <i class="fas fa-chevron-down down-arrow"></i>
+      </button>
+    </div>
 
-      <div> : </div>
+    <div> : </div>
 
-      <div class="time-unit-col">
-        <button type="button"
-                data-testid="next_minute_button"
-                @click="go_to_next_minute"
-                class="up-button">
-          <i class="fas fa-chevron-up up-arrow"></i>
-        </button>
-        <div>
-          <input type="text"
-                 class="minute-input"
-                 :value="minutes_str"
-                 @keydown="update_minutes"/>
-        </div>
-        <button type="button"
-                data-testid="prev_minute_button"
-                @click="go_to_prev_minute"
-                class="down-button">
-          <i class="fas fa-chevron-down down-arrow"></i>
-        </button>
+    <div class="time-unit-col">
+      <button type="button"
+              data-testid="next_minute_button"
+              @click="go_to_next_minute"
+              class="up-button">
+        <i class="fas fa-chevron-up up-arrow"></i>
+      </button>
+      <div>
+        <input type="text"
+                class="minute-input"
+                :value="minutes_str"
+                @keydown="update_minutes"/>
       </div>
+      <button type="button"
+              data-testid="prev_minute_button"
+              @click="go_to_prev_minute"
+              class="down-button">
+        <i class="fas fa-chevron-down down-arrow"></i>
+      </button>
+    </div>
 
-      <div></div>
+    <div></div>
 
-      <div class="time-unit-col">
-        <div>
-          <input class="period-input"
-                 type="button"
-                 v-model="am_pm_str"
-                 @click="toggle_period_value"/>
-        </div>
+    <div class="time-unit-col">
+      <div>
+        <input class="period-input"
+                type="button"
+                v-model="am_pm_str"
+                @click="toggle_period_value"/>
       </div>
     </div>
   </div>
@@ -273,20 +271,15 @@ export class InvalidTimeStrError extends Error {
 @import '@/styles/button_styles.scss';
 
 .timepicker {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 210px;
-}
-
-.timepicker-header {
   align-items: center;
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
-  justify-content: space-evenly;
-  padding: .875rem;
   text-align: center;
+}
+
+.time-unit-col {
+  padding: 0 .125rem;
 }
 
 .hour-input, .minute-input {

--- a/tests/test_components/test_datetime/test_datetime_picker.ts
+++ b/tests/test_components/test_datetime/test_datetime_picker.ts
@@ -47,8 +47,6 @@ describe('DatetimePicker tests', () => {
         await wrapper.vm.$nextTick();
 
         let now = moment();
-        console.log(now);
-        console.log(wrapper.vm.d_date);
 
         expect(wrapper.vm.d_month).toEqual(now.month());
         expect(wrapper.vm.d_year).toEqual(now.year());

--- a/tests/test_components/test_datetime/test_datetime_picker.ts
+++ b/tests/test_components/test_datetime/test_datetime_picker.ts
@@ -13,15 +13,8 @@ import { emitted, set_props } from '@/tests/utils';
 
 
 describe('DatetimePicker tests', () => {
-    beforeEach(() => {
-        timezone_mock.register('US/Eastern');
-    });
-
-    afterEach(() => {
-        timezone_mock.unregister();
-    });
-
     test('Month, year, day, and time are initialized from input', async () => {
+        sinon.stub(moment.tz, 'guess').returns('US/Eastern');
         let wrapper = mount(DatetimePicker, {
             propsData: {
                 value: "2019-12-25T18:36:37.746Z"
@@ -48,26 +41,29 @@ describe('DatetimePicker tests', () => {
     });
 
     test('Initial value null, no day highlighted until day selected', async () => {
+        // Intentionally NOT mocking moment.tz.guess()
         let wrapper = mount(DatetimePicker);
         wrapper.vm.show();
         await wrapper.vm.$nextTick();
 
-        let now = new Date();
+        let now = moment();
+        console.log(now);
+        console.log(wrapper.vm.d_date);
 
-        expect(wrapper.vm.d_month).toEqual(now.getMonth());
-        expect(wrapper.vm.d_year).toEqual(now.getFullYear());
+        expect(wrapper.vm.d_month).toEqual(now.month());
+        expect(wrapper.vm.d_year).toEqual(now.year());
 
         expect(wrapper.vm.d_selected_day).toBeNull();
         expect(wrapper.vm.d_selected_month).toBeNull();
         expect(wrapper.vm.d_selected_year).toBeNull();
 
-        expect(wrapper.vm.d_date.date()).toEqual(now.getDate());
-        expect(wrapper.vm.d_date.month()).toEqual(now.getMonth());
-        expect(wrapper.vm.d_date.year()).toEqual(now.getFullYear());
+        expect(wrapper.vm.d_date.date()).toEqual(now.date());
+        expect(wrapper.vm.d_date.month()).toEqual(now.month());
+        expect(wrapper.vm.d_date.year()).toEqual(now.year());
 
         let time_picker = <Wrapper<TimePicker>> wrapper.findComponent({ref: 'time_picker'});
-        expect(time_picker.vm.d_time.hours).toEqual(now.getHours());
-        let minutes_diff = Math.abs(time_picker.vm.d_time.minutes - now.getMinutes());
+        expect(time_picker.vm.d_time.hours).toEqual(now.hours());
+        let minutes_diff = Math.abs(time_picker.vm.d_time.minutes - now.minutes());
         expect(minutes_diff).toBeLessThan(1);
 
         wrapper.vm.show();
@@ -80,17 +76,18 @@ describe('DatetimePicker tests', () => {
         await first_week.findAll('.available-day').at(0).trigger('click');
 
         expect(wrapper.vm.d_selected_day).toEqual(1);
-        expect(wrapper.vm.d_selected_month).toEqual(now.getMonth());
-        expect(wrapper.vm.d_selected_year).toEqual(now.getFullYear());
+        expect(wrapper.vm.d_selected_month).toEqual(now.month());
+        expect(wrapper.vm.d_selected_year).toEqual(now.year());
 
         expect(emitted(wrapper, 'input').length).toBe(1);
         let emitted_date = new Date(emitted(wrapper, 'input')[0][0]);
-        expect(emitted_date.getFullYear()).toEqual(now.getFullYear());
-        expect(emitted_date.getMonth()).toEqual(now.getMonth());
+        expect(emitted_date.getFullYear()).toEqual(now.year());
+        expect(emitted_date.getMonth()).toEqual(now.month());
         expect(emitted_date.getDate()).toEqual(1);
     });
 
     test('Initial value null, time change before day selected does not emit', async () => {
+        sinon.stub(moment.tz, 'guess').returns('US/Eastern');
         let wrapper = mount(DatetimePicker);
         wrapper.vm.show();
         await wrapper.vm.$nextTick();
@@ -114,7 +111,7 @@ describe('DatetimePicker tests', () => {
     test('Invalid date str throws exception', () => {
         sinon.stub(console, 'error');
         sinon.stub(console, 'warn');
-        timezone_mock.unregister();
+        // timezone_mock.unregister();
         expect(() => {
             mount(DatetimePicker, {
                 propsData: {
@@ -160,6 +157,7 @@ describe('DatetimePicker tests', () => {
     });
 
     test("Value passed into 'value' prop changed by parent component", async () => {
+        sinon.stub(moment.tz, 'guess').returns('US/Eastern');
         let orig_date_string = "2019-07-21T12:20:40.746Z";
         let wrapper = mount(DatetimePicker, {
             propsData: {
@@ -225,11 +223,7 @@ describe('DatetimePicker tests', () => {
 
 describe('DatetimePicker keyboard inputs', () => {
     beforeEach(() => {
-        timezone_mock.register('US/Eastern');
-    });
-
-    afterEach(() => {
-        timezone_mock.unregister();
+        sinon.stub(moment.tz, 'guess').returns('US/Eastern');
     });
 
     test('Pressing left arrow goes to previous month (with year wraparound)', async () => {
@@ -275,9 +269,8 @@ describe('DatetimePicker keyboard inputs', () => {
     });
 });
 
-describe.only('Timezone select tests', () => {
+describe('Timezone select tests', () => {
     beforeEach(() => {
-        timezone_mock.register('US/Pacific');
         sinon.stub(moment.tz, 'guess').returns('US/Pacific');
     });
 

--- a/tests/test_components/test_project_admin/test_edit_groups/test_edit_single_group.ts
+++ b/tests/test_components/test_project_admin/test_edit_groups/test_edit_single_group.ts
@@ -7,7 +7,7 @@ import {
     Project,
 } from 'ag-client-typescript';
 // @ts-ignore
-import moment from 'moment';
+import moment from 'moment-timezone';
 import * as sinon from "sinon";
 
 import APIErrors from '@/components/api_errors.vue';
@@ -36,7 +36,7 @@ describe('EditSingleGroup tests', () => {
         });
 
         group = data_ut.make_group(project.pk, 2, {
-            extended_due_date: "2019-04-18T15:26:06.965696Z",
+            extended_due_date: "2019-04-18T15:26:06Z",
             member_names: [
                 "kevin@cornell.edu",
                 "oscar@cornell.edu"
@@ -118,7 +118,7 @@ describe('EditSingleGroup tests', () => {
         let now = moment();
         picker.vm.set_date_and_time(now.format());
         picker.vm.update_time_selected();
-        expect(wrapper.vm.d_group?.extended_due_date).toEqual(now.format());
+        expect(moment(wrapper.vm.d_group?.extended_due_date).format()).toEqual(now.format());
     });
 
     test('API errors displayed on submit', async () => {


### PR DESCRIPTION
This makes it more convenient to set deadlines when the user is in a different timezone.

Fixes #469 
Related to https://github.com/eecs-autograder/autograder.io/issues/12