### PR TITLE
Submission limit reset timezone enhancements

### DIFF
--- a/src/components/course_admin/manage_projects/manage_projects.vue
+++ b/src/components/course_admin/manage_projects/manage_projects.vue
@@ -50,6 +50,7 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { Course, Project, ProjectObserver } from 'ag-client-typescript';
+import moment from 'moment-timezone';
 
 import APIErrors from "@/components/api_errors.vue";
 import SingleProject from '@/components/course_admin/manage_projects/single_project.vue';
@@ -105,7 +106,11 @@ export default class ManageProjects extends Vue implements ProjectObserver,
       this.d_adding_project = true;
       this.new_project_name.trim();
       let new_project: Project = await Project.create(
-        this.course.pk, {name: this.new_project_name}
+        this.course.pk,
+        {
+          name: this.new_project_name,
+          submission_limit_reset_timezone: moment.tz.guess()
+        }
       );
       this.new_project_name = "";
       (<ValidatedForm> this.$refs.new_project_form).reset_warning_state();

--- a/src/components/project_admin/project_settings.vue
+++ b/src/components/project_admin/project_settings.vue
@@ -443,6 +443,7 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { Project, UltimateSubmissionPolicy } from 'ag-client-typescript';
+import moment from "moment-timezone";
 
 import APIErrors from '@/components/api_errors.vue';
 import DatetimePicker from "@/components/datetime/datetime_picker.vue";
@@ -484,13 +485,9 @@ export default class ProjectSettings extends Vue {
   @Prop({required: true, type: Project})
   project!: Project;
 
-  readonly timezones: ReadonlyArray<string> = [
-    'US/Central',
-    'US/Eastern',
-    'US/Mountain',
-    'US/Pacific',
-    'UTC'
-  ];
+  get timezones() {
+    return moment.tz.names();
+  }
 
   d_project: Project | null = null;
   d_saving = false;

--- a/tests/test_components/test_course_admin/test_manage_projects/test_manage_projects.ts
+++ b/tests/test_components/test_course_admin/test_manage_projects/test_manage_projects.ts
@@ -1,6 +1,7 @@
 import { Wrapper } from '@vue/test-utils';
 
 import { Course, HttpError, Project, User } from 'ag-client-typescript';
+import moment from 'moment-timezone';
 import * as sinon from 'sinon';
 
 import APIErrors from '@/components/api_errors.vue';
@@ -88,7 +89,8 @@ describe('Manage projects tests', () => {
         await wrapper.vm.$nextTick();
 
         expect(create_project_stub.firstCall.calledWith(
-            current_course.pk, { name: new_project.name }
+            current_course.pk,
+            {name: new_project.name, submission_limit_reset_timezone: moment.tz.guess()}
         )).toBe(true);
         expect(wrapper.vm.projects.length).toEqual(3);
         expect(wrapper.vm.projects[0]).toEqual(new_project);


### PR DESCRIPTION
Updated submission limit reset timezone to include full list of timezone.
Fixes #468 

Also set submission_limit_reset_timezone to the local timezone when a new project is created.
Fixes #287 