### PR TITLE
Fix rejected handgrade

### DIFF
--- a/src/components/project_view/handgrading/group_summary_panel.vue
+++ b/src/components/project_view/handgrading/group_summary_panel.vue
@@ -4,7 +4,7 @@
          'graded': status === HandgradingStatus.graded,
          'ungraded': status === HandgradingStatus.ungraded,
          'in-progress': status === HandgradingStatus.in_progress,
-         'no-submission': status === HandgradingStatus.no_submission,
+         'no-valid-submission': status === HandgradingStatus.no_valid_submission,
        }"
        v-on="$listeners">
     <div class="member-names">
@@ -78,8 +78,10 @@ export default class GroupSummaryPanel extends Vue {
   color: $ocean-blue;
 }
 
-.no-submission {
+no-valid-submission {
   color: $stormy-gray-dark;
+  background-color: aqua;
+  pointer-events: none; // Make the panel unclickable
 }
 
 </style>

--- a/src/components/project_view/handgrading/group_summary_panel.vue
+++ b/src/components/project_view/handgrading/group_summary_panel.vue
@@ -78,9 +78,8 @@ export default class GroupSummaryPanel extends Vue {
   color: $ocean-blue;
 }
 
-no-valid-submission {
+.no-valid-submission {
   color: $stormy-gray-dark;
-  background-color: aqua;
   pointer-events: none; // Make the panel unclickable
 }
 

--- a/src/components/project_view/handgrading/handgrading_container.vue
+++ b/src/components/project_view/handgrading/handgrading_container.vue
@@ -68,12 +68,12 @@
                   </div>
                   <div class="radio-container">
                     <input type="radio" name="status"
-                            id="no-submission"
+                            id="no-valid-submission"
                             class="radio"
                             v-model="d_status_filter"
-                            :value="HandgradingStatus.no_submission">
+                            :value="HandgradingStatus.no_valid_submission">
                     <label class="label"
-                            for="no-submission">{{HandgradingStatus.no_submission}}</label>
+                            for="no-valid-submission">{{HandgradingStatus.no_valid_submission}}</label>
                   </div>
                 </div>
               </div>
@@ -234,7 +234,7 @@ export default class HandgradingContainer extends Vue implements ag_cli.Handgrad
 
   get total_num_to_grade() {
     return this.staff_filtered_groups.filter(
-      group => get_handgrading_status(group) !== HandgradingStatus.no_submission
+      group => get_handgrading_status(group) !== HandgradingStatus.no_valid_submission
     ).length;
   }
 

--- a/src/components/project_view/handgrading/handgrading_status.ts
+++ b/src/components/project_view/handgrading/handgrading_status.ts
@@ -8,7 +8,7 @@ export enum HandgradingStatus {
 }
 
 export function get_handgrading_status(group_summary: GroupWithHandgradingResultSummary) {
-    if (group_summary.num_submissions === 0) {
+    if (group_summary.num_submits_towards_limit === 0) {
       return HandgradingStatus.no_submission;
     }
 

--- a/src/components/project_view/handgrading/handgrading_status.ts
+++ b/src/components/project_view/handgrading/handgrading_status.ts
@@ -1,7 +1,7 @@
 import { GroupWithHandgradingResultSummary } from 'ag-client-typescript';
 
 export enum HandgradingStatus {
-    no_submission = "No Submission",
+    no_valid_submission = "No Valid Submissions",
     ungraded = "Ungraded",
     in_progress = "In Progress",
     graded = "Graded",
@@ -9,7 +9,7 @@ export enum HandgradingStatus {
 
 export function get_handgrading_status(group_summary: GroupWithHandgradingResultSummary) {
     if (group_summary.num_submits_towards_limit === 0) {
-      return HandgradingStatus.no_submission;
+      return HandgradingStatus.no_valid_submission;
     }
 
     let result = group_summary.handgrading_result;

--- a/src/components/project_view/handgrading/handgrading_status.ts
+++ b/src/components/project_view/handgrading/handgrading_status.ts
@@ -8,7 +8,7 @@ export enum HandgradingStatus {
 }
 
 export function get_handgrading_status(group_summary: GroupWithHandgradingResultSummary) {
-    if (group_summary.num_submits_towards_limit === 0) {
+    if (!group_summary.has_handgradeable_submission) {
       return HandgradingStatus.no_valid_submission;
     }
 

--- a/tests/test_components/test_project_view/test_handgrading/test_handgrading_container.ts
+++ b/tests/test_components/test_project_view/test_handgrading/test_handgrading_container.ts
@@ -17,6 +17,7 @@ let project: ag_cli.Project;
 let rubric: ag_cli.HandgradingRubric;
 
 let no_submissions_group: ag_cli.GroupWithHandgradingResultSummary;
+let no_valid_submission_group: ag_cli.GroupWithHandgradingResultSummary;
 let ungraded_group: ag_cli.GroupWithHandgradingResultSummary;
 let in_progress_group: ag_cli.GroupWithHandgradingResultSummary;
 let graded_group: ag_cli.GroupWithHandgradingResultSummary;
@@ -44,6 +45,9 @@ beforeEach(() => {
 
     no_submissions_group = data_ut.make_group_summary(
         project.pk, 1, {member_names: ['none@me.com']});
+    no_valid_submission_group = data_ut.make_group_summary(
+        project.pk, 1, {member_names: ['no-valid@me.com'], num_submissions: 1,
+        num_submits_towards_limit: 0});
     ungraded_group = data_ut.make_group_summary(
         project.pk, 1, {member_names: ['not_yet@me.com'], num_submissions: 1});
     in_progress_group = data_ut.make_group_summary(
@@ -147,7 +151,7 @@ describe('Filter group summaries tests', () => {
         expect(wrapper.findAllComponents({name: 'GroupSummaryPanel'}).length).toBe(1);
         expect(summary_pks(wrapper)).toEqual([ungraded_group.pk]);
 
-        wrapper.find('#no-submission').setChecked();
+        wrapper.find('#no-valid-submission').setChecked();
         await wrapper.vm.$nextTick();
         expect(wrapper.findAllComponents({name: 'GroupSummaryPanel'}).length).toBe(1);
         expect(summary_pks(wrapper)).toEqual([no_submissions_group.pk]);

--- a/tests/test_components/test_project_view/test_handgrading/test_handgrading_status.ts
+++ b/tests/test_components/test_project_view/test_handgrading/test_handgrading_status.ts
@@ -29,7 +29,7 @@ test('get_handgrading_status', () => {
     expect(get_handgrading_status(ungraded)).toEqual(HandgradingStatus.ungraded);
 
     let no_submission = data_ut.make_group_summary(
-        project.pk, 1, {num_submissions: 0},
+        project.pk, 1, {num_submits_towards_limit: 0},
     );
     expect(get_handgrading_status(no_submission)).toEqual(HandgradingStatus.no_submission);
 });

--- a/tests/test_components/test_project_view/test_handgrading/test_handgrading_status.ts
+++ b/tests/test_components/test_project_view/test_handgrading/test_handgrading_status.ts
@@ -28,8 +28,9 @@ test('get_handgrading_status', () => {
     );
     expect(get_handgrading_status(ungraded)).toEqual(HandgradingStatus.ungraded);
 
-    let no_submission = data_ut.make_group_summary(
+    let no_valid_submission = data_ut.make_group_summary(
         project.pk, 1, {num_submits_towards_limit: 0},
     );
-    expect(get_handgrading_status(no_submission)).toEqual(HandgradingStatus.no_submission);
+    expect(get_handgrading_status(no_valid_submission))
+        .toEqual(HandgradingStatus.no_valid_submission);
 });


### PR DESCRIPTION
@james-perretta  Would you mind taking a look once you get some time? Thanks.

Addressing [this issue](https://github.com/eecs-autograder/autograder.io/issues/31)

<b> Before:</b>
![image](https://github.com/eecs-autograder/ag-website-vue/assets/14872803/1a9d1ff5-ba33-4c64-9064-5c2db1d6af4d)

<b> After </b>
![image](https://github.com/eecs-autograder/ag-website-vue/assets/14872803/6295112e-4eeb-4ffc-9d43-5a5bd01e6e37)
<img width="1246" alt="Screenshot 2024-04-17 at 14 32 30" src="https://github.com/eecs-autograder/ag-website-vue/assets/14872803/c64ad2b2-5bc3-4fa8-b0b6-14e1bb955ce1">

Instead of showing `ungraded` for the handgrading status of student group whose submissions were all rejected, the UI would now determine the status by checking whether there is a submission that is counted towards the submission limit. If the student group does not have a submission that count towards the limit, the UI would indicate the handgrading status as "No Valid Submission" and not clickable.

As demonstrated, this fix has been tested on a real student submission. We may introduce additional unit/regression tests if needed in future.