### PR TITLE
Make "Actual exit status" always black when return code is not checked

### DIFF
--- a/src/components/project_view/submission_detail/ag_test_command_result_detail.vue
+++ b/src/components/project_view/submission_detail/ag_test_command_result_detail.vue
@@ -33,6 +33,8 @@
                         {'actual-return-code-correct': ag_test_command_result !== null
                           && ag_test_command_result.return_code_correct,
                           'actual-return-code-incorrect': ag_test_command_result !== null
+                          // return_code_correct can be null so we need to check for false
+                          // to avoid showing the red warning color when it's null
                           && ag_test_command_result.return_code_correct === false}]"
           >{{ag_test_command_result.actual_return_code}}</div>
         </div>

--- a/src/components/project_view/submission_detail/ag_test_command_result_detail.vue
+++ b/src/components/project_view/submission_detail/ag_test_command_result_detail.vue
@@ -33,7 +33,7 @@
                         {'actual-return-code-correct': ag_test_command_result !== null
                           && ag_test_command_result.return_code_correct,
                           'actual-return-code-incorrect': ag_test_command_result !== null
-                          && !ag_test_command_result.return_code_correct}]"
+                          && ag_test_command_result.return_code_correct === false}]"
           >{{ag_test_command_result.actual_return_code}}</div>
         </div>
       </div>

--- a/tests/test_components/test_project_view/test_submission_detail/test_ag_test_command_result_detail.ts
+++ b/tests/test_components/test_project_view/test_submission_detail/test_ag_test_command_result_detail.ts
@@ -164,6 +164,17 @@ describe('Correctness feedback tests', () => {
             );
         });
 
+        test('Actual return code available, return code not checked', async () => {
+            ag_test_command_result.expected_return_code = ag_cli.ExpectedReturnCode.none;
+            ag_test_command_result.return_code_correct = null;
+            // https://github.com/eecs-autograder/autograder.io/issues/30
+            // Any status should be correct, including 2
+            ag_test_command_result.actual_return_code = 2;
+            let wrapper = await make_wrapper();
+            let section_wrapper = wrapper.findComponent({ref: 'actual_return_code'});
+            expect(section_wrapper.find('.actual-return-code-incorrect').exists()).toBe(false);
+        });
+
         test('Expected return code available, return code not checked', async () => {
             ag_test_command_result.expected_return_code = ag_cli.ExpectedReturnCode.none;
             let wrapper = await make_wrapper();


### PR DESCRIPTION
This PR addresses https://github.com/eecs-autograder/autograder.io/issues/30.

When applying classes to the _Actual exit status_ code, it changes the check for `ag_test_command_result.return_code_correct` from `!ag_test_command_result.return_code_correct` to `ag_test_command_result.return_code_correct === false` so that the incorrect return code class is no longer applied if `ag_test_command_result.return_code_correct` is `null`.

I have included a new test that verifies this functionality. Without the change above, the test fails.

## Screenshots

**Before**

![Screenshot 2024-04-20 at 00-36-35 Autograder io](https://github.com/eecs-autograder/ag-website-vue/assets/10491561/ca1927b4-f3e9-47bb-9449-f4f18a451808)

**After**

![Screenshot 2024-04-20 at 00-36-56 Autograder io](https://github.com/eecs-autograder/ag-website-vue/assets/10491561/80da2044-660f-4eeb-804e-a765ecb4b5cb)

@james-perretta Please review this at your earliest convenience. Thank you!