### PR TITLE
Added grey color hovering for submission panel

### DIFF
--- a/src/components/submission_list/submission_panel.vue
+++ b/src/components/submission_list/submission_panel.vue
@@ -103,4 +103,9 @@ export default class SubmissionPanel extends Vue {
     color: $navy-blue;
   }
 }
+
+.submission-list-item:hover {
+  background-color: $pebble-light;
+}
+
 </style>


### PR DESCRIPTION
Addressing issue [362](https://github.com/eecs-autograder/ag-website-vue/issues/362), added grey hovering to submission panels.

![Convert to GIF project May 22](https://github.com/eecs-autograder/ag-website-vue/assets/14872803/6779adb7-23d4-42d2-aa62-b9db175b80ad)

![Convert to GIF project May 22 (1)](https://github.com/eecs-autograder/ag-website-vue/assets/14872803/3c57df08-0277-43c1-b8e9-47a58676356e)

@james-perretta, I just don't think I can find an effective way to test this in jest. Feel free to give some recommendations!