### PR TITLE
Changed tooltip location to be not covered

### DIFF
--- a/src/components/project_admin/ag_tests/ag_test_command_settings.vue
+++ b/src/components/project_admin/ag_tests/ag_test_command_settings.vue
@@ -50,7 +50,7 @@
       <div class="form-field-wrapper">
         <label class="label">
           Command
-          <tooltip width="large" placement="top">
+          <tooltip width="large" placement="right">
             Can be any valid bash command. <br>
             Note that if it includes sequencing or piping,
             you will have to increase the process limit.

--- a/src/components/project_admin/ag_tests/ag_test_command_settings.vue
+++ b/src/components/project_admin/ag_tests/ag_test_command_settings.vue
@@ -51,9 +51,7 @@
         <label class="label">
           Command
           <tooltip width="large" placement="right">
-            Can be any valid bash command. <br>
-            Note that if it includes sequencing or piping,
-            you will have to increase the process limit.
+            Can be any valid bash command.
           </tooltip>
         </label>
         <validated-input ref="cmd"


### PR DESCRIPTION
Addressing [this issue](https://github.com/eecs-autograder/ag-website-vue/issues/472)

Changed the tool-tip's location from top to right to make visible the entire message.

<b> Before </b>
<img width="1126" alt="Screenshot 2024-05-22 at 22 52 21" src="https://github.com/eecs-autograder/ag-website-vue/assets/14872803/3efd5e22-4ad1-4f97-8ff9-3f37fea6e561">

<b> After </b>
<img width="1175" alt="Screenshot 2024-05-22 at 22 50 55" src="https://github.com/eecs-autograder/ag-website-vue/assets/14872803/fcdee501-4c51-4506-bbdd-4c3f6269ac1a">

@james-perretta, what outdated text should be deleted? Is it `Note that if it includes sequencing or piping, you will have to increase the process limit.` part?
