### PR TITLE
Fix group members form for group registration

### DIFF
--- a/src/components/group_members_form.vue
+++ b/src/components/group_members_form.vue
@@ -55,10 +55,9 @@ export default class GroupMembersForm extends Vue {
   course!: Course;
 
   @Prop({
-    required: false,
-    default: null,
+    required: true,
     type: Number,
-    validator: (value: number) => value > 0
+    validator: (value: number | null) => value === null || value > 0
   })
   max_num_inputs!: number | null;
 

--- a/src/components/group_members_form.vue
+++ b/src/components/group_members_form.vue
@@ -24,7 +24,7 @@
       <div class="add-member-container">
         <button class="add-member-button"
                 type="button"
-                :disabled="d_usernames.length >= max_num_inputs && !ignore_group_size_limits"
+                :disabled="max_num_inputs != null && d_usernames.length >= max_num_inputs"
                 @click="add_member">
           <i class="fas fa-plus"></i>
           Add Member
@@ -38,7 +38,7 @@
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
-import { Course, Project } from 'ag-client-typescript';
+import { Course } from 'ag-client-typescript';
 
 import ValidatedForm from '@/components/validated_form.vue';
 import ValidatedInput from '@/components/validated_input.vue';
@@ -51,21 +51,23 @@ import { is_email } from '@/validators';
   }
 })
 export default class GroupMembersForm extends Vue {
-  @Prop({required: true, type: Project})
-  project!: Project;
-
   @Prop({required: true, type: Course})
   course!: Course;
 
-  // In some cases, the maximum number of members will be less
-  // than the Project's max_group_size (group invitations, for example).
-  // When provided, this field be used to determine the maximum number
-  // of text inputs.
-  @Prop({default: null, type: Number})
-  max_num_members!: number | null;
+  @Prop({
+    required: false,
+    default: null,
+    type: Number,
+    validator: (value: number) => value > 0
+  })
+  max_num_inputs!: number | null;
 
-  @Prop({default: false, type: Boolean})
-  ignore_group_size_limits!: boolean;
+  @Prop({
+    required: true,
+    type: Number,
+    validator: (value: number) => value > 0
+  })
+  min_num_inputs!: number;
 
   @Prop({default: () => [], type: Array})
   value!: string[];
@@ -94,17 +96,6 @@ export default class GroupMembersForm extends Vue {
   reset() {
     (<ValidatedForm> this.$refs.group_members_form).reset_warning_state();
     this.initialize(this.value);
-  }
-
-  get max_num_inputs() {
-    return this.max_num_members !== null ? this.max_num_members : this.project.max_group_size;
-  }
-
-  get min_num_inputs() {
-    if (this.ignore_group_size_limits) {
-      return 1;
-    }
-    return Math.min(this.project.min_group_size, this.max_num_inputs);
   }
 
   private add_member() {

--- a/src/components/project_admin/edit_groups/edit_single_group.vue
+++ b/src/components/project_admin/edit_groups/edit_single_group.vue
@@ -7,7 +7,8 @@
 
     <group-members-form v-model="d_group.member_names"
                         ref="edit_group_form"
-                        :project="project"
+                        :min_num_inputs="1"
+                        :max_num_inputs="null"
                         :course="course"
                         @submit="update_group"
                         @form_validity_changed="d_edit_group_form_is_valid = $event"

--- a/src/components/project_view/group_registration/group_registration.vue
+++ b/src/components/project_view/group_registration/group_registration.vue
@@ -94,9 +94,9 @@
            click_outside_to_close>
       <div class="modal-header"> Send Invitation </div>
       <group-members-form ref="send_invitation_form"
-                          :project="project"
+                          :min_num_inputs="Math.max(1, project.min_group_size - 1)"
+                          :max_num_inputs="project.max_group_size - 1"
                           :course="course"
-                          :max_num_members="project.max_group_size - 1"
                           @submit="send_invitation">
         <template v-slot:header>
           <div class="users-to-invite-label"> Users to Invite: </div>

--- a/tests/test_components/test_group_members_form.ts
+++ b/tests/test_components/test_group_members_form.ts
@@ -1,31 +1,23 @@
 import { mount, Wrapper } from '@vue/test-utils';
 
-import { Course, Project } from 'ag-client-typescript';
+import { Course } from 'ag-client-typescript';
 
 import GroupMembersForm from '@/components/group_members_form.vue';
 import ValidatedInput from '@/components/validated_input.vue';
 
-import { make_course, make_project } from '@/tests/data_utils';
+import { make_course } from '@/tests/data_utils';
 import { emitted, get_validated_input_text, set_validated_input_text } from '@/tests/utils';
 
 let course: Course = make_course({allowed_guest_domain: '@llama.net'});
-let project: Project;
-
-beforeEach(() => {
-    project = make_project(course.pk);
-});
 
 describe('GroupMembersForm tests', () => {
     test('Default value prop, d_usernames initialized based on min_num_inputs', () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
                 course: course,
+                min_num_inputs: 4,
+                max_num_inputs: 7,
             },
-            computed: {
-                min_num_inputs: () => 4,
-                max_num_inputs: () => 8
-            }
         });
 
         expect(wrapper.vm.d_usernames).toEqual(
@@ -41,7 +33,6 @@ describe('GroupMembersForm tests', () => {
         let value = ['spam', 'egg'];
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
                 course: course,
                 value: value
             }
@@ -57,57 +48,12 @@ describe('GroupMembersForm tests', () => {
         }
     });
 
-    test('max_num_inputs is project.max_group_size when max_num_members is null', () => {
-        project.max_group_size = 42;
+    test('min_num_inputs is 1 with no max_num_inputs', () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
                 course: course,
-            }
-        });
-        expect(wrapper.vm.max_num_inputs).toEqual(project.max_group_size);
-    });
-
-    test('max_num_inputs is max_num_members when max_num_members is non-null', () => {
-        project.max_group_size = 42;
-        let wrapper = mount(GroupMembersForm, {
-            propsData: {
-                project: project,
-                course: course,
-                max_num_members: 40,
-            }
-        });
-        expect(wrapper.vm.max_num_inputs).toEqual(40);
-    });
-
-    test('min_num_inputs is min of project.min_group_size and max_num_inputs', () => {
-        project.min_group_size = 1;
-        let options = {
-            propsData: {
-                project: project,
-                course: course,
-            },
-            computed: {
-                max_num_inputs: () => 3
-            }
-        };
-        let wrapper = mount(GroupMembersForm, options);
-        expect(wrapper.vm.min_num_inputs).toEqual(1);
-
-        wrapper.destroy();
-        project.min_group_size = 5;
-        wrapper = mount(GroupMembersForm, options);
-        expect(wrapper.vm.min_num_inputs).toEqual(3);
-    });
-
-    test('min_num_inputs is 1 when ignore_group_size_limits is true', () => {
-        project.min_group_size = 2;
-        project.max_group_size = 3;
-        let wrapper = mount(GroupMembersForm, {
-            propsData: {
-                project: project,
-                course: course,
-                ignore_group_size_limits: true,
+                min_num_inputs: 1,
+                max_num_inputs: null,
             },
         });
 
@@ -117,14 +63,11 @@ describe('GroupMembersForm tests', () => {
     test('Add member button disabled when num inputs is max_num_inputs', () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
                 course: course,
-                value: ['', '', '']
+                value: ['', '', ''],
+                min_num_inputs: 1,
+                max_num_inputs: 3,
             },
-            computed: {
-                min_num_inputs: () => 1,
-                max_num_inputs: () => 3
-            }
         });
 
         expect(wrapper.find('.add-member-button').element).toBeDisabled();
@@ -133,14 +76,11 @@ describe('GroupMembersForm tests', () => {
     test('Remove member buttons disabled when num inputs is min_num_inputs', () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
                 course: course,
-                value: ['', '']
+                value: ['', ''],
+                min_num_inputs: 2,
+                max_num_inputs: 3,
             },
-            computed: {
-                min_num_inputs: () => 2,
-                max_num_inputs: () => 3
-            }
         });
 
         let remove_buttons = wrapper.findAll('.remove-member-button');
@@ -150,10 +90,10 @@ describe('GroupMembersForm tests', () => {
     });
 
     test('Add member', async () => {
-        project.max_group_size = 2;
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
+                min_num_inputs: 1,
+                max_num_inputs: 2,
                 course: course,
                 value: ['spam']
             }
@@ -171,11 +111,11 @@ describe('GroupMembersForm tests', () => {
     });
 
     test('Remove member', async () => {
-        project.max_group_size = 2;
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
                 course: course,
+                min_num_inputs: 1,
+                max_num_inputs: 2,
                 value: ['spam', 'egg']
             }
         });
@@ -197,7 +137,7 @@ describe('GroupMembersForm tests', () => {
     test('value watcher', async () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
+                min_num_inputs: 1,
                 course: course,
                 value: ['spam']
             }
@@ -213,8 +153,8 @@ describe('GroupMembersForm tests', () => {
     test('Username input invalid non-email', async () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
                 course: course,
+                min_num_inputs: 2,
                 value: ['spam', 'egg@spam.com']
             }
         });
@@ -231,7 +171,7 @@ describe('GroupMembersForm tests', () => {
     test('reset()', async () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
+                min_num_inputs: 1,
                 course: course,
             }
         });
@@ -250,7 +190,7 @@ describe('GroupMembersForm tests', () => {
         let value = ['spam@egg.net', 'wa@luigi.net'];
         let wrapper = mount(GroupMembersForm, {
             propsData: {
-                project: project,
+                min_num_inputs: 2,
                 course: course,
                 value: value
             }

--- a/tests/test_components/test_group_members_form.ts
+++ b/tests/test_components/test_group_members_form.ts
@@ -34,7 +34,9 @@ describe('GroupMembersForm tests', () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
                 course: course,
-                value: value
+                value: value,
+                min_num_inputs: 2,
+                max_num_inputs: 2
             }
         });
 
@@ -138,6 +140,7 @@ describe('GroupMembersForm tests', () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
                 min_num_inputs: 1,
+                max_num_inputs: null,
                 course: course,
                 value: ['spam']
             }
@@ -155,6 +158,7 @@ describe('GroupMembersForm tests', () => {
             propsData: {
                 course: course,
                 min_num_inputs: 2,
+                max_num_inputs: null,
                 value: ['spam', 'egg@spam.com']
             }
         });
@@ -172,6 +176,7 @@ describe('GroupMembersForm tests', () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
                 min_num_inputs: 1,
+                max_num_inputs: null,
                 course: course,
             }
         });
@@ -191,6 +196,7 @@ describe('GroupMembersForm tests', () => {
         let wrapper = mount(GroupMembersForm, {
             propsData: {
                 min_num_inputs: 2,
+                max_num_inputs: null,
                 course: course,
                 value: value
             }

--- a/tests/test_components/test_project_view/test_group_registration/test_group_registration.ts
+++ b/tests/test_components/test_project_view/test_group_registration/test_group_registration.ts
@@ -79,7 +79,7 @@ describe('GroupRegistration tests', () => {
         sinon.stub(user, 'group_invitations_sent').returns(Promise.resolve([]));
 
         project.min_group_size = 3
-        project.max_group_size = 3
+        project.max_group_size = 5
         wrapper = managed_mount(GroupRegistration, {
             propsData: {
                 project: project,
@@ -100,7 +100,7 @@ describe('GroupRegistration tests', () => {
         const invitation_form = wrapper.findComponent({ref: 'send_invitation_form'});
         expect(invitation_form.exists()).toBe(true);
         expect(invitation_form.vm.min_num_inputs).toEqual(2);
-        expect(invitation_form.vm.max_num_inputs).toEqual(2);
+        expect(invitation_form.vm.max_num_inputs).toEqual(4);
 
         // make sure default number of inputs is the min group size, and neither can be removed
         const username_inputs = invitation_form.findAllComponents({ref: 'username_input'});

--- a/tests/test_components/test_project_view/test_group_registration/test_group_registration.ts
+++ b/tests/test_components/test_project_view/test_group_registration/test_group_registration.ts
@@ -71,6 +71,74 @@ describe('GroupRegistration tests', () => {
         ).toBe(true);
     });
 
+    test('min and max number of inputs are one less than the min and max group size', async () => {
+        // This is the only case where the minimum number of inputs should not be 1 less
+        // than the min_group_size. If the student intends to work alone they should use the work
+        // alone button.
+        sinon.stub(user, 'group_invitations_received').returns(Promise.resolve([]));
+        sinon.stub(user, 'group_invitations_sent').returns(Promise.resolve([]));
+
+        project.min_group_size = 3
+        project.max_group_size = 3
+        wrapper = managed_mount(GroupRegistration, {
+            propsData: {
+                project: project,
+                course: course
+            },
+        });
+        expect(await wait_for_load(wrapper)).toBe(true);
+
+        expect(wrapper.findComponent({ref: 'send_group_invitation_modal'}).exists()).toBe(false);
+        expect(wrapper.vm.invitation_sent).toEqual(null);
+
+        await wrapper.find('#send-group-invitation-button').trigger('click');
+
+        const modal = wrapper.findComponent({ref: 'send_group_invitation_modal'});
+        expect(modal.exists()).toBe(true);
+        expect(wrapper.vm.d_show_send_group_invitation_modal).toBe(true);
+
+        const invitation_form = wrapper.findComponent({ref: 'send_invitation_form'});
+        expect(invitation_form.exists()).toBe(true);
+        expect(invitation_form.vm.min_num_inputs).toEqual(2);
+        expect(invitation_form.vm.max_num_inputs).toEqual(2);
+
+        // make sure default number of inputs is the min group size, and neither can be removed
+        const username_inputs = invitation_form.findAllComponents({ref: 'username_input'});
+        expect(username_inputs.length).toEqual(2);
+    });
+
+    test('Min group size 1, min number of form inputs is 1 (not min_group_size - 1 like normal)', async () => {
+        // This is the only case where the minimum number of inputs should not be 1 less
+        // than the min_group_size. If the student intends to work alone they should use the work
+        // alone button.
+        sinon.stub(user, 'group_invitations_received').returns(Promise.resolve([]));
+        sinon.stub(user, 'group_invitations_sent').returns(Promise.resolve([]));
+
+        project.min_group_size = 1
+        project.max_group_size = 3
+        wrapper = managed_mount(GroupRegistration, {
+            propsData: {
+                project: project,
+                course: course
+            },
+        });
+        expect(await wait_for_load(wrapper)).toBe(true);
+
+        expect(wrapper.findComponent({ref: 'send_group_invitation_modal'}).exists()).toBe(false);
+        expect(wrapper.vm.invitation_sent).toEqual(null);
+
+        await wrapper.find('#send-group-invitation-button').trigger('click');
+
+        const modal = wrapper.findComponent({ref: 'send_group_invitation_modal'});
+        expect(modal.exists()).toBe(true);
+        expect(wrapper.vm.d_show_send_group_invitation_modal).toBe(true);
+
+        const invitation_form = wrapper.findComponent({ref: 'send_invitation_form'});
+        expect(invitation_form.exists()).toBe(true);
+        expect(invitation_form.vm.min_num_inputs).toEqual(1);
+        expect(invitation_form.vm.max_num_inputs).toEqual(2);
+    });
+
     test('created - Project.disallow_group_registration is true', async () => {
         sinon.stub(user, 'group_invitations_received').returns(Promise.resolve([]));
         sinon.stub(user, 'group_invitations_sent').returns(Promise.resolve([]));
@@ -585,9 +653,11 @@ describe('GroupRegistration tests', () => {
         expect(wrapper.findComponent({ref: 'send_group_invitation_modal'}).exists()).toBe(true);
         expect(wrapper.vm.d_show_send_group_invitation_modal).toBe(true);
 
+        console.log('before submit')
         wrapper.findComponent({ref: 'send_invitation_form'}).vm.$emit('submit', [user.username]);
         expect(await wait_until(wrapper, w => !w.vm.d_sending_invitation)).toBe(true);
         await wrapper.vm.$nextTick();
+        console.log('after submit')
 
         expect(send_invitation_stub.calledOnce).toBe(true);
         expect(send_invitation_stub.firstCall.calledWith(project.pk, [user.username])).toBe(true);
@@ -595,6 +665,7 @@ describe('GroupRegistration tests', () => {
         expect(wrapper.vm.d_show_send_group_invitation_modal).toBe(true);
         expect(wrapper.vm.invitation_sent).toEqual(null);
 
+        console.log('later')
         let api_errors = <APIErrors> wrapper.findComponent({ref: 'send_invitation_api_errors'}).vm;
         expect(api_errors.d_api_errors.length).toBe(1);
     });


### PR DESCRIPTION
Fixed behavior:
- min number of inputs on the form is now min_group_size - 1, and max is max_group_size - 1
- One exception is min_group_size is 1, then min number of inputs is 1. This is what was hiding the bug before, because many classes allowed students to work alone or in groups. The result of this is really just a more sensible default value when a student clicks the register group button when min_group_size=1 and max_group_size>1 as well as to prevent people submitting empty group invitations.