### PR TITLE
Increase e2e test timeout to prevent flaky tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  timeout: 5000,
+  timeout: 15000,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   fullyParallel: true,


### PR DESCRIPTION
e2e tests fail on my laptop when the CPU is throttled (not plugged in). Increasing the timeout makes the tests less flaky. 

10s passes reliably on my machine unplugged, so I increased it to 15s for some wiggle room.

Note that the default expect() timeout is 5s, which is unchanged. 