### PR TITLE
Put quotes around discarded files in submission views

### DIFF
--- a/src/components/project_view/submission_detail/submission_detail.vue
+++ b/src/components/project_view/submission_detail/submission_detail.vue
@@ -141,7 +141,7 @@
         <div v-for="filename of submission.discarded_files" class="discarded-file"
              role="listitem">
           <i class="far fa-trash-alt"></i>
-          {{filename}}
+          "{{filename}}"
         </div>
       </div>
     </div>

--- a/src/components/project_view/submit.vue
+++ b/src/components/project_view/submit.vue
@@ -132,7 +132,8 @@
           <i class="fas fa-exclamation-triangle"></i>
         </div>
         <ul class="file-list">
-          <li v-for="filename of unexpected_files" class="list-item filename">{{filename}}</li>
+          <li v-for="filename of unexpected_files"
+              class="list-item filename">"{{filename}}"</li>
           <li v-for="mismatch of patterns_with_too_many_matches" class="list-item">
             Expected no more than
             <span class="num-files">{{mismatch.num_expected}}</span>

--- a/tests/test_components/test_project_view/test_submission_detail/test_submission_detail.ts
+++ b/tests/test_components/test_project_view/test_submission_detail/test_submission_detail.ts
@@ -345,8 +345,8 @@ describe('Discarded files tests', () => {
         let discarded = wrapper.findAll('.discarded-file');
         expect(discarded.length).toEqual(discarded_filenames.length);
 
-        expect(compress_whitespace(discarded.at(0).text())).toEqual(discarded_filenames[0]);
-        expect(compress_whitespace(discarded.at(1).text())).toEqual(discarded_filenames[1]);
+        expect(compress_whitespace(discarded.at(0).text())).toEqual(`"${discarded_filenames[0]}"`);
+        expect(compress_whitespace(discarded.at(1).text())).toEqual(`"${discarded_filenames[1]}"`);
     });
 });
 

--- a/tests/test_components/test_project_view/test_submit.ts
+++ b/tests/test_components/test_project_view/test_submit.ts
@@ -845,7 +845,7 @@ describe('Submitted file validation tests', () => {
 
         let unexpected_files = confirm_submit_modal.findAll('.file-list').at(2);
         expect(unexpected_files.findAll('li').length).toEqual(2);
-        expect(unexpected_files.findAll('li').at(0).text()).toEqual('unexpected');
+        expect(unexpected_files.findAll('li').at(0).text()).toEqual('"unexpected"');
         expect(compress_whitespace(unexpected_files.findAll('li').at(1).text())).toEqual(
             'Expected no more than 2 file(s) matching the pattern too_many_* but got 3'
         );


### PR DESCRIPTION
Wrap filenames in quotes in both places where discarded files are shown: the "extra files detected" list before submitting (files that will be discarded) and the "files were discarded" list on the submission detail (files that were discarded). Quoting makes the file boundaries unambiguous, e.g. for names with spaces.

Fixes #504