### PR TITLE
Accessibility fix for remove user button in course admin roster

### DIFF
--- a/src/components/course_admin/roster/roster.vue
+++ b/src/components/course_admin/roster/roster.vue
@@ -50,11 +50,12 @@
           <td class="email-column email">{{person.username}}</td>
           <td class="name-column name">{{person.first_name}} {{person.last_name}}</td>
           <td class="remove-user-column">
-            <i class="fas fa-user-times remove-user"
-                :title="'Delete ' + person.username"
-                tabindex="0"
-                @click="remove_person_from_roster([person], index)">
-            </i>
+            <button type="button"
+                    class="remove-user unstyled-button"
+                    :aria-label="'Delete ' + person.username"
+                    @click="remove_person_from_roster([person], index)">
+              <i class="fas fa-user-times" aria-hidden="true"></i>
+            </button>
           </td>
         </tr>
       </table>
@@ -261,7 +262,6 @@ function parse_emails(to_parse: string): {valid_emails: string[], invalid_emails
 
 .remove-user {
   color: hsl(212, 10%, 47%);
-  cursor: pointer;
 
   &:hover {
     color: $navy-blue;


### PR DESCRIPTION
Converts the remove-user icon to a native button with an aria label.

Part of #537